### PR TITLE
specify Maven minimum version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -512,6 +512,26 @@
   <build>
     <pluginManagement>
       <plugins>
+          <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-enforcer-plugin</artifactId>
+              <version>1.4.1</version>
+              <executions>
+                <execution>
+                  <id>enforce-maven</id>
+                  <goals>
+                    <goal>enforce</goal>
+                  </goals>
+                  <configuration>
+                    <rules>
+                      <requireMavenVersion>
+                        <version>3.8.1</version>
+                      </requireMavenVersion>
+                    </rules>
+                  </configuration>
+                </execution>
+              </executions>
+            </plugin>
         <plugin>
           <groupId>biz.aQute.bnd</groupId>
           <artifactId>bnd-maven-plugin</artifactId>
@@ -688,6 +708,10 @@
       </plugins>
     </pluginManagement>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+      </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>flatten-maven-plugin</artifactId>


### PR DESCRIPTION
Compiling project with Maven version lower to 3.8.1 fails and stop on error 

`
[ERROR] Failed to execute goal biz.aQute.bnd:bnd-maven-plugin:7.0.0:bnd-process (default) on project annotation: The plugin biz.aQute.bnd:bnd-maven-plugin:7.0.0 requires Maven version 3.8.1 -> [Help 1]`

=> Maven should specify the minimum version to 3.8.1 to stop on compile's precondition check