### PR TITLE
Fixed failure result creation due to missing originalDto field

### DIFF
--- a/core/impl/src/main/java/org/eclipse/sensinact/core/extract/impl/AnnotationMapping.java
+++ b/core/impl/src/main/java/org/eclipse/sensinact/core/extract/impl/AnnotationMapping.java
@@ -99,6 +99,7 @@ public class AnnotationMapping {
                     String.format("The mapping for class %s is not properly defined", clazz.getName()), t);
             return o -> {
                 FailedMappingDto fmd = new FailedMappingDto();
+                fmd.originalDto = o;
                 fmd.mappingFailure = fail;
                 return List.of(fmd);
             };


### PR DESCRIPTION
When a custom DTO is not defined correctly, the DataUpdate should return a failed promise with a DataMappingException.
The DataMappingException requires the originalDto to be non null, which wasn't the case in the fixed snippet.