### PR TITLE
Ensure filtering properly removes services and resources

### DIFF
--- a/core/impl/src/main/java/org/eclipse/sensinact/core/impl/snapshot/ProviderSnapshotImpl.java
+++ b/core/impl/src/main/java/org/eclipse/sensinact/core/impl/snapshot/ProviderSnapshotImpl.java
@@ -101,14 +101,4 @@ public class ProviderSnapshotImpl extends AbstractSnapshot implements ProviderSn
     public Provider getModelProvider() {
         return modelProvider;
     }
-
-    public void filterEmptyServices() {
-        Iterator<Entry<String, ServiceSnapshotImpl>> iter = services.entrySet().iterator();
-        while (iter.hasNext()) {
-            Entry<String, ServiceSnapshotImpl> entry = iter.next();
-            if (entry.getValue().getResources().isEmpty()) {
-                iter.remove();
-            }
-        }
-    }
 }

--- a/core/impl/src/test/java/org/eclipse/sensinact/core/integration/filter/FilterTest.java
+++ b/core/impl/src/test/java/org/eclipse/sensinact/core/integration/filter/FilterTest.java
@@ -79,11 +79,10 @@ public class FilterTest {
         final ProviderSnapshot provider = providers.iterator().next();
         assertEquals("model_1", provider.getModelName());
         assertEquals("provider_1", provider.getName());
-        // We should have all 4 services + admin
-        assertEquals(5, provider.getServices().size());
+        // We should have only the service we asked for
+        assertEquals(1, provider.getServices().size());
 
-        final ServiceSnapshot service = provider.getServices().stream().filter(s -> "service_1".equals(s.getName()))
-                .findFirst().get();
+        final ServiceSnapshot service = provider.getService("service_1");
         assertEquals(1, service.getResources().size());
 
         final ResourceSnapshot resource = service.getResources().get(0);

--- a/core/impl/src/test/java/org/eclipse/sensinact/core/twin/impl/SensinactTwinTest.java
+++ b/core/impl/src/test/java/org/eclipse/sensinact/core/twin/impl/SensinactTwinTest.java
@@ -313,6 +313,14 @@ public class SensinactTwinTest {
             twinImpl.createProvider(TEST_MODEL, TEST_PROVIDER);
             list = twinImpl.filteredSnapshot(null, null, null, null);
             assertEquals(2, list.size());
+            ProviderSnapshot ps = list.stream().filter(p -> TEST_PROVIDER.equals(p.getName())).findFirst().get();
+
+            assertEquals(2, ps.getServices().size());
+            ServiceSnapshot ss = ps.getService(TEST_SERVICE);
+            assertNotNull(ss);
+            assertEquals(2, ss.getResources().size());
+            assertNotNull(ss.getResource(TEST_RESOURCE));
+            assertNotNull(ss.getResource(TEST_ACTION_RESOURCE));
         }
 
         @Test
@@ -365,9 +373,9 @@ public class SensinactTwinTest {
 
             List<ProviderSnapshot> list = twinImpl.filteredSnapshot(null, null, null, p);
             assertEquals(1, list.size());
-            assertEquals(2, list.get(0).getServices().size());
-            ServiceSnapshot serviceSnapshot = list.get(0).getServices().stream()
-                    .filter(s -> TEST_SERVICE.equals(s.getName())).findFirst().get();
+            assertEquals(1, list.get(0).getServices().size());
+            ServiceSnapshot serviceSnapshot = list.get(0).getService(TEST_SERVICE);
+            assertNotNull(serviceSnapshot);
             assertEquals(5, serviceSnapshot.getResources().get(0).getValue().getValue());
         }
 
@@ -398,10 +406,14 @@ public class SensinactTwinTest {
 
             List<ProviderSnapshot> list = twinImpl.filteredSnapshot(null, null, null, p);
             assertEquals(1, list.size());
-            assertEquals(4, list.get(0).getServices().size());
-            ServiceSnapshot serviceSnapshot = list.get(0).getServices().stream()
-                    .filter(s -> TEST_SERVICE.equals(s.getName())).findFirst().get();
+            assertEquals(2, list.get(0).getServices().size());
+            ServiceSnapshot serviceSnapshot = list.get(0).getService(TEST_SERVICE);
+            assertNotNull(serviceSnapshot);
             assertEquals("fizz", serviceSnapshot.getResources().get(0).getValue().getValue());
+
+            serviceSnapshot = list.get(0).getService("testService1");
+            assertNotNull(serviceSnapshot);
+            assertEquals("foo", serviceSnapshot.getResources().get(0).getValue().getValue());
         }
     }
 }


### PR DESCRIPTION
Filtering should only add services and resources which pass the filters. Services with no resources should be excluded, as should providers with no services. This commit ensures the minimal snapshot is created and returned.

Fixes #517