### PR TITLE
Ensure that metadata set commands pass successfully

### DIFF
--- a/core/impl/src/main/java/org/eclipse/sensinact/core/extract/impl/AnnotationMapping.java
+++ b/core/impl/src/main/java/org/eclipse/sensinact/core/extract/impl/AnnotationMapping.java
@@ -59,15 +59,14 @@ public class AnnotationMapping {
 
             List<Function<Object, ? extends AbstractUpdateDto>> list = new ArrayList<>();
 
-            // Include metadata updates first so that any data changes publish up to date metadata
-            for (Entry<Field, Metadata> e : metadataFields.entrySet()) {
-                list.add(createMetaDataMapping(clazz, e.getKey(), e.getValue()));
-            }
-
             for (Entry<Field, Data> e : dataFields.entrySet()) {
                 list.add(createDataMapping(clazz, e.getKey(), e.getValue()));
             }
 
+            // Include metadata updates second so that any new resources are created first
+            for (Entry<Field, Metadata> e : metadataFields.entrySet()) {
+                list.add(createMetaDataMapping(clazz, e.getKey(), e.getValue()));
+            }
 
             return o -> {
                 Instant t = null;

--- a/core/impl/src/main/java/org/eclipse/sensinact/core/extract/impl/EMFGenericDtoDataExtractor.java
+++ b/core/impl/src/main/java/org/eclipse/sensinact/core/extract/impl/EMFGenericDtoDataExtractor.java
@@ -60,21 +60,20 @@ public class EMFGenericDtoDataExtractor implements DataExtractor {
         }
 
         List<AbstractUpdateDto> list = new ArrayList<>();
-        // Include metadata updates first so that any data changes publish up to date metadata
+        // Accept a null value if this is not a metadata update
+        if (dto.value != null || dto.nullAction != NullAction.IGNORE) {
+            DataUpdateDto dud = copyCommonFields(dto, instant, new DataUpdateDto());
+            dud.type = dto.type;
+            dud.data = dto.value;
+            dud.modelEClass = dto.modelEClass;
+            list.add(dud);
+        }
+
+        // Include metadata updates second so that any new resources are created first
         if (dto.metadata != null) {
             MetadataUpdateDto dud = copyCommonFields(dto, instant, new MetadataUpdateDto());
             dud.metadata = dto.metadata;
             dud.removeNullValues = true;
-            list.add(dud);
-        }
-
-        // Accept a null value if this is not a metadata update
-        if (dto.value != null || dto.nullAction != NullAction.IGNORE) {
-            DataUpdateDto dud = copyCommonFields(dto, instant, new DataUpdateDto());
-            if (dto.type != null)
-                dud.type = dto.type;
-            dud.data = dto.value;
-            dud.modelEClass = dto.modelEClass;
             list.add(dud);
         }
 

--- a/core/impl/src/main/java/org/eclipse/sensinact/core/extract/impl/GenericDtoDataExtractor.java
+++ b/core/impl/src/main/java/org/eclipse/sensinact/core/extract/impl/GenericDtoDataExtractor.java
@@ -56,22 +56,21 @@ public class GenericDtoDataExtractor implements DataExtractor {
 
         List<AbstractUpdateDto> list = new ArrayList<>();
 
-        // Include metadata updates first so that any data changes publish up to date metadata
+        // Accept a null value if this is not a pure metadata update
+        if (dto.value != null || dto.nullAction != NullAction.IGNORE) {
+            DataUpdateDto dud = copyCommonFields(dto, instant, new DataUpdateDto());
+            dud.type = dto.type;
+            dud.data = dto.value;
+            dud.actionOnDuplicate = dto.duplicateDataAction;
+            list.add(dud);
+        }
+
+        // Include metadata updates second so that any new resources are created first
         if (dto.metadata != null) {
             MetadataUpdateDto dud = copyCommonFields(dto, instant, new MetadataUpdateDto());
             dud.metadata = dto.metadata;
             dud.removeNullValues = true;
             dud.actionOnDuplicate = dto.duplicateMetadataAction;
-            list.add(dud);
-        }
-
-        // Accept a null value if this is not a pure metadata update
-        if (dto.value != null || dto.nullAction != NullAction.IGNORE) {
-            DataUpdateDto dud = copyCommonFields(dto, instant, new DataUpdateDto());
-            if (dto.type != null)
-                dud.type = dto.type;
-            dud.data = dto.value;
-            dud.actionOnDuplicate = dto.duplicateDataAction;
             list.add(dud);
         }
 

--- a/core/impl/src/main/java/org/eclipse/sensinact/core/impl/SetValueCommand.java
+++ b/core/impl/src/main/java/org/eclipse/sensinact/core/impl/SetValueCommand.java
@@ -101,8 +101,10 @@ public class SetValueCommand extends AbstractSensinactCommand<Void> {
 
             Resource r = service.getResources().get(res);
             if (!model.isFrozen() && r == null) {
+                Class<?> type = dataUpdateDto.type != null ? dataUpdateDto.type :
+                    dataUpdateDto.data != null ? dataUpdateDto.data.getClass() : null;
                 r = service.createResource(res).withValueType(ValueType.UPDATABLE)
-                        .withType((Class<?>) dataUpdateDto.type).build();
+                        .withType(type).build();
             }
             if (svcEClass == null) {
                 svcEClass = service.getServiceEClass();

--- a/core/impl/src/main/java/org/eclipse/sensinact/core/notification/impl/NotificationAccumulatorImpl.java
+++ b/core/impl/src/main/java/org/eclipse/sensinact/core/notification/impl/NotificationAccumulatorImpl.java
@@ -24,6 +24,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
@@ -235,6 +236,9 @@ public class NotificationAccumulatorImpl extends AbstractNotificationAccumulator
                         newValuesToUse = nonNullNewValues;
                         timestampToUse = timestamp;
                     }
+                    Optional.ofNullable(notifications.get(
+                            new NotificationKey(provider, service, resource, ResourceDataNotification.class)))
+                            .ifPresent(rdn -> ((ResourceDataNotification)rdn.get(0)).metadata = newValuesToUse);
                     return List.of(createResourceMetaDataNotification(modelPackageUri, model, provider, service, resource,
                             oldValuesToUse, newValuesToUse, timestampToUse));
                 });

--- a/core/impl/src/test/java/org/eclipse/sensinact/core/extract/impl/GenericDtoExtractorTest.java
+++ b/core/impl/src/test/java/org/eclipse/sensinact/core/extract/impl/GenericDtoExtractorTest.java
@@ -301,6 +301,11 @@ public class GenericDtoExtractorTest {
             AbstractUpdateDto extracted = updates.get(0);
 
             checkCommonFields(extracted);
+            assertTrue(extracted instanceof DataUpdateDto, "Not a data update dto " + extracted.getClass());
+            assertEquals(NullAction.UPDATE, extracted.actionOnNull);
+
+            extracted = updates.get(1);
+            checkCommonFields(extracted);
             assertTrue(extracted instanceof MetadataUpdateDto, "Not a metadata update dto " + extracted.getClass());
 
             MetadataUpdateDto dud = (MetadataUpdateDto) extracted;
@@ -310,12 +315,6 @@ public class GenericDtoExtractorTest {
             assertFalse(dud.removeMissingValues, "Missing values should be kept");
             assertEquals(NullAction.UPDATE, dud.actionOnNull);
             assertEquals(DuplicateAction.UPDATE_IF_DIFFERENT, dud.actionOnDuplicate);
-
-            extracted = updates.get(1);
-
-            checkCommonFields(extracted);
-            assertTrue(extracted instanceof DataUpdateDto, "Not a metadata update dto " + extracted.getClass());
-            assertEquals(NullAction.UPDATE, extracted.actionOnNull);
         }
 
         @Test

--- a/core/impl/src/test/java/org/eclipse/sensinact/core/notification/impl/NotificationSenderTest.java
+++ b/core/impl/src/test/java/org/eclipse/sensinact/core/notification/impl/NotificationSenderTest.java
@@ -510,6 +510,25 @@ class NotificationSenderTest {
         }
 
         @Test
+        void testUpdateValueThenMetadata() {
+            Instant now = Instant.now();
+
+            accumulator.resourceValueUpdate(MODEL_PKG, MODEL, PROVIDER, SERVICE, RESOURCE, Integer.class, null, INTEGER_VALUE,
+                    Map.of(METADATA_KEY, METADATA_VALUE), now);
+            accumulator.metadataValueUpdate(MODEL_PKG, MODEL, PROVIDER, SERVICE, RESOURCE,
+                    Map.of(METADATA_KEY, METADATA_VALUE), Map.of(METADATA_KEY, METADATA_VALUE_2), now);
+            accumulator.completeAndSend();
+
+            Mockito.verify(bus).deliver(eq("DATA/" + MODEL + "/" + PROVIDER + "/" + SERVICE + "/" + RESOURCE), argThat(
+                    isValueNotificationWith(PROVIDER, SERVICE, RESOURCE, Integer.class, null, INTEGER_VALUE,
+                            Map.of(METADATA_KEY, METADATA_VALUE_2), now)));
+            Mockito.verify(bus).deliver(eq("METADATA/" + MODEL + "/" + PROVIDER + "/" + SERVICE + "/" + RESOURCE),
+                    argThat(isMetadataNotificationWith(PROVIDER, SERVICE, RESOURCE, Map.of(METADATA_KEY, METADATA_VALUE),
+                            Map.of(METADATA_KEY, METADATA_VALUE_2), now)));
+            Mockito.verifyNoMoreInteractions(bus);
+        }
+
+        @Test
         void testMultipleUpdate() {
             Instant now = Instant.now();
 


### PR DESCRIPTION
Try to write data values first, but ensure to update the data notification's metadata if metadata changes later.


Fixes #519 