### PR TITLE
Make NotificationAccumulator private

### DIFF
--- a/core/api/src/main/java/org/eclipse/sensinact/core/command/DependentCommand.java
+++ b/core/api/src/main/java/org/eclipse/sensinact/core/command/DependentCommand.java
@@ -63,7 +63,7 @@ public abstract class DependentCommand<P, T> extends AbstractSensinactCommand<T>
         private final Promise<P> parentResult;
 
         public ChildCommand(Promise<P> parentResult) {
-            super(DependentCommand.this.getAccumulator());
+            super();
             this.parentResult = parentResult;
         }
 

--- a/core/api/src/main/java/org/eclipse/sensinact/core/command/GatewayThread.java
+++ b/core/api/src/main/java/org/eclipse/sensinact/core/command/GatewayThread.java
@@ -12,7 +12,6 @@
 **********************************************************************/
 package org.eclipse.sensinact.core.command;
 
-import org.eclipse.sensinact.core.notification.NotificationAccumulator;
 import org.osgi.util.promise.Promise;
 import org.osgi.util.promise.PromiseFactory;
 
@@ -21,8 +20,6 @@ public interface GatewayThread {
     public PromiseFactory getPromiseFactory();
 
     public <T> Promise<T> execute(AbstractSensinactCommand<T> command);
-
-    public NotificationAccumulator createAccumulator();
 
     public static GatewayThread getGatewayThread() {
         Thread currentThread = Thread.currentThread();

--- a/core/emf-api/src/main/java/org/eclipse/sensinact/core/emf/command/AbstractSensinactEMFCommand.java
+++ b/core/emf-api/src/main/java/org/eclipse/sensinact/core/emf/command/AbstractSensinactEMFCommand.java
@@ -18,7 +18,6 @@ import org.eclipse.sensinact.core.command.AbstractSensinactCommand;
 import org.eclipse.sensinact.core.emf.model.SensinactEMFModelManager;
 import org.eclipse.sensinact.core.emf.twin.SensinactEMFDigitalTwin;
 import org.eclipse.sensinact.core.model.SensinactModelManager;
-import org.eclipse.sensinact.core.notification.NotificationAccumulator;
 import org.eclipse.sensinact.core.twin.SensinactDigitalTwin;
 import org.osgi.util.promise.Promise;
 import org.osgi.util.promise.PromiseFactory;
@@ -29,13 +28,10 @@ public abstract class AbstractSensinactEMFCommand<T> extends AbstractSensinactCo
         super();
     }
 
-    protected AbstractSensinactEMFCommand(NotificationAccumulator accumulator) {
-        super(accumulator);
-    }
-
     protected abstract Promise<T> call(SensinactEMFDigitalTwin twin, SensinactEMFModelManager modelMgr,
             PromiseFactory promiseFactory);
 
+    @Override
     protected Promise<T> call(SensinactDigitalTwin twin, SensinactModelManager modelMgr, PromiseFactory pf) {
         return call((SensinactEMFDigitalTwin) twin, (SensinactEMFModelManager) modelMgr, pf);
     }

--- a/core/impl/src/main/java/org/eclipse/sensinact/core/model/nexus/ModelNexus.java
+++ b/core/impl/src/main/java/org/eclipse/sensinact/core/model/nexus/ModelNexus.java
@@ -58,7 +58,7 @@ import org.eclipse.sensinact.core.model.ResourceType;
 import org.eclipse.sensinact.core.model.nexus.emf.EMFUtil;
 import org.eclipse.sensinact.core.model.nexus.emf.NamingUtils;
 import org.eclipse.sensinact.core.model.nexus.emf.compare.EMFCompareUtil;
-import org.eclipse.sensinact.core.notification.NotificationAccumulator;
+import org.eclipse.sensinact.core.notification.impl.NotificationAccumulator;
 import org.eclipse.sensinact.core.twin.TimedValue;
 import org.eclipse.sensinact.core.twin.impl.TimedValueImpl;
 import org.eclipse.sensinact.core.whiteboard.impl.SensinactWhiteboard;

--- a/core/impl/src/main/java/org/eclipse/sensinact/core/model/nexus/emf/compare/EMFCompareUtil.java
+++ b/core/impl/src/main/java/org/eclipse/sensinact/core/model/nexus/emf/compare/EMFCompareUtil.java
@@ -30,7 +30,7 @@ import org.eclipse.emf.ecore.ETypedElement;
 import org.eclipse.emf.ecore.EcorePackage;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.sensinact.core.model.nexus.emf.EMFUtil;
-import org.eclipse.sensinact.core.notification.NotificationAccumulator;
+import org.eclipse.sensinact.core.notification.impl.NotificationAccumulator;
 import org.eclipse.sensinact.model.core.metadata.MetadataFactory;
 import org.eclipse.sensinact.model.core.metadata.MetadataPackage;
 import org.eclipse.sensinact.model.core.metadata.ResourceMetadata;

--- a/core/impl/src/main/java/org/eclipse/sensinact/core/notification/impl/AbstractNotificationAccumulatorImpl.java
+++ b/core/impl/src/main/java/org/eclipse/sensinact/core/notification/impl/AbstractNotificationAccumulatorImpl.java
@@ -16,11 +16,10 @@ import java.time.Instant;
 import java.util.Map;
 
 import org.eclipse.sensinact.core.notification.LifecycleNotification;
-import org.eclipse.sensinact.core.notification.NotificationAccumulator;
+import org.eclipse.sensinact.core.notification.LifecycleNotification.Status;
 import org.eclipse.sensinact.core.notification.ResourceActionNotification;
 import org.eclipse.sensinact.core.notification.ResourceDataNotification;
 import org.eclipse.sensinact.core.notification.ResourceMetaDataNotification;
-import org.eclipse.sensinact.core.notification.LifecycleNotification.Status;
 
 /**
  * This class is allows some level of implementation sharing between the
@@ -97,6 +96,7 @@ public abstract class AbstractNotificationAccumulatorImpl implements Notificatio
         return rn;
     }
 
+    @Override
     public final void completeAndSend() {
         check();
         complete = true;

--- a/core/impl/src/main/java/org/eclipse/sensinact/core/notification/impl/ImmediateNotificationAccumulator.java
+++ b/core/impl/src/main/java/org/eclipse/sensinact/core/notification/impl/ImmediateNotificationAccumulator.java
@@ -25,7 +25,6 @@ import java.util.Map;
 import java.util.Objects;
 
 import org.eclipse.sensinact.core.notification.LifecycleNotification;
-import org.eclipse.sensinact.core.notification.NotificationAccumulator;
 import org.eclipse.sensinact.core.notification.ResourceActionNotification;
 import org.eclipse.sensinact.core.notification.ResourceDataNotification;
 import org.eclipse.sensinact.core.notification.ResourceMetaDataNotification;
@@ -192,6 +191,7 @@ public class ImmediateNotificationAccumulator extends AbstractNotificationAccumu
         eventBus.deliver(ran.getTopic(), ran);
     }
 
+    @Override
     protected void doComplete() {
         // No op by default
     }

--- a/core/impl/src/main/java/org/eclipse/sensinact/core/notification/impl/NotificationAccumulator.java
+++ b/core/impl/src/main/java/org/eclipse/sensinact/core/notification/impl/NotificationAccumulator.java
@@ -10,7 +10,7 @@
 * Contributors:
 *   Kentyou - initial implementation
 **********************************************************************/
-package org.eclipse.sensinact.core.notification;
+package org.eclipse.sensinact.core.notification.impl;
 
 import java.time.Instant;
 import java.util.Map;

--- a/core/impl/src/main/java/org/eclipse/sensinact/core/notification/impl/NotificationAccumulatorImpl.java
+++ b/core/impl/src/main/java/org/eclipse/sensinact/core/notification/impl/NotificationAccumulatorImpl.java
@@ -32,11 +32,10 @@ import java.util.stream.Stream;
 
 import org.eclipse.sensinact.core.notification.AbstractResourceNotification;
 import org.eclipse.sensinact.core.notification.LifecycleNotification;
-import org.eclipse.sensinact.core.notification.NotificationAccumulator;
+import org.eclipse.sensinact.core.notification.LifecycleNotification.Status;
 import org.eclipse.sensinact.core.notification.ResourceActionNotification;
 import org.eclipse.sensinact.core.notification.ResourceDataNotification;
 import org.eclipse.sensinact.core.notification.ResourceMetaDataNotification;
-import org.eclipse.sensinact.core.notification.LifecycleNotification.Status;
 import org.osgi.service.typedevent.TypedEventBus;
 
 /**

--- a/core/impl/src/test/java/org/eclipse/sensinact/core/model/impl/ModelBuildingTest.java
+++ b/core/impl/src/test/java/org/eclipse/sensinact/core/model/impl/ModelBuildingTest.java
@@ -32,7 +32,7 @@ import org.eclipse.sensinact.core.model.Resource;
 import org.eclipse.sensinact.core.model.ResourceType;
 import org.eclipse.sensinact.core.model.Service;
 import org.eclipse.sensinact.core.model.nexus.ModelNexus;
-import org.eclipse.sensinact.core.notification.NotificationAccumulator;
+import org.eclipse.sensinact.core.notification.impl.NotificationAccumulator;
 import org.eclipse.sensinact.core.snapshot.ProviderSnapshot;
 import org.eclipse.sensinact.core.snapshot.ResourceSnapshot;
 import org.eclipse.sensinact.core.snapshot.ServiceSnapshot;

--- a/core/impl/src/test/java/org/eclipse/sensinact/core/model/nexus/impl/NexusTest.java
+++ b/core/impl/src/test/java/org/eclipse/sensinact/core/model/nexus/impl/NexusTest.java
@@ -59,7 +59,7 @@ import org.eclipse.emf.ecore.xmi.XMLResource;
 import org.eclipse.sensinact.core.emf.util.EMFTestUtil;
 import org.eclipse.sensinact.core.model.nexus.ModelNexus;
 import org.eclipse.sensinact.core.model.nexus.emf.EMFUtil;
-import org.eclipse.sensinact.core.notification.NotificationAccumulator;
+import org.eclipse.sensinact.core.notification.impl.NotificationAccumulator;
 import org.eclipse.sensinact.model.core.provider.Admin;
 import org.eclipse.sensinact.model.core.provider.DynamicProvider;
 import org.eclipse.sensinact.model.core.provider.Provider;

--- a/core/impl/src/test/java/org/eclipse/sensinact/core/model/nexus/impl/SubscriptionTest.java
+++ b/core/impl/src/test/java/org/eclipse/sensinact/core/model/nexus/impl/SubscriptionTest.java
@@ -54,7 +54,7 @@ import org.eclipse.emf.ecore.xmi.XMLResource;
 import org.eclipse.sensinact.core.emf.util.EMFTestUtil;
 import org.eclipse.sensinact.core.model.nexus.ModelNexus;
 import org.eclipse.sensinact.core.model.nexus.emf.EMFUtil;
-import org.eclipse.sensinact.core.notification.NotificationAccumulator;
+import org.eclipse.sensinact.core.notification.impl.NotificationAccumulator;
 import org.eclipse.sensinact.model.core.metadata.ResourceMetadata;
 import org.eclipse.sensinact.model.core.provider.Admin;
 import org.eclipse.sensinact.model.core.provider.DynamicProvider;

--- a/core/impl/src/test/java/org/eclipse/sensinact/core/notification/impl/NotificationSenderTest.java
+++ b/core/impl/src/test/java/org/eclipse/sensinact/core/notification/impl/NotificationSenderTest.java
@@ -31,11 +31,10 @@ import java.util.Map;
 
 import org.eclipse.sensinact.core.model.nexus.emf.EMFUtil;
 import org.eclipse.sensinact.core.notification.LifecycleNotification;
-import org.eclipse.sensinact.core.notification.NotificationAccumulator;
+import org.eclipse.sensinact.core.notification.LifecycleNotification.Status;
 import org.eclipse.sensinact.core.notification.ResourceActionNotification;
 import org.eclipse.sensinact.core.notification.ResourceDataNotification;
 import org.eclipse.sensinact.core.notification.ResourceMetaDataNotification;
-import org.eclipse.sensinact.core.notification.LifecycleNotification.Status;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;

--- a/core/impl/src/test/java/org/eclipse/sensinact/core/twin/impl/SensinactTwinTest.java
+++ b/core/impl/src/test/java/org/eclipse/sensinact/core/twin/impl/SensinactTwinTest.java
@@ -46,7 +46,7 @@ import org.eclipse.sensinact.core.model.ResourceType;
 import org.eclipse.sensinact.core.model.impl.SensinactModelManagerImpl;
 import org.eclipse.sensinact.core.model.nexus.ModelNexus;
 import org.eclipse.sensinact.core.model.nexus.emf.EMFUtil;
-import org.eclipse.sensinact.core.notification.NotificationAccumulator;
+import org.eclipse.sensinact.core.notification.impl.NotificationAccumulator;
 import org.eclipse.sensinact.core.snapshot.ProviderSnapshot;
 import org.eclipse.sensinact.core.snapshot.ResourceSnapshot;
 import org.eclipse.sensinact.core.snapshot.ServiceSnapshot;


### PR DESCRIPTION
It seems there is no interest into having the NotificationAccumulator as public API, as discussed in #496 

This PR proposes the changes required to move NotificationAccumulator into the core.impl bundle