### PR TITLE
Add a default TimedValue implementation

### DIFF
--- a/core/api/dependency-check.bndrun
+++ b/core/api/dependency-check.bndrun
@@ -1,6 +1,6 @@
 -runrequires: bnd.identity;id='${project.groupId}.${project.artifactId}'
 -runfw: org.apache.felix.framework
--runee: JavaSE-11
+-runee: JavaSE-17
 
 # These packages are also provided by the gecko.emf.osgi.component project
 # so we blacklist the API for resolve consistency

--- a/core/api/src/main/java/org/eclipse/sensinact/core/snapshot/ICriterionSupport.java
+++ b/core/api/src/main/java/org/eclipse/sensinact/core/snapshot/ICriterionSupport.java
@@ -25,6 +25,7 @@ import java.util.stream.Stream;
 import org.eclipse.sensinact.core.model.ResourceType;
 import org.eclipse.sensinact.core.model.ValueType;
 import org.eclipse.sensinact.core.notification.ResourceDataNotification;
+import org.eclipse.sensinact.core.twin.DefaultTimedValue;
 import org.eclipse.sensinact.core.twin.TimedValue;
 import org.eclipse.sensinact.gateway.geojson.GeoJsonObject;
 
@@ -150,17 +151,7 @@ class ResourceDataBackedResourceSnapshot implements ResourceSnapshot {
 
     @Override
     public TimedValue<?> getValue() {
-        return new TimedValue<Object>() {
-            @Override
-            public Instant getTimestamp() {
-                return service.provider.rdn.timestamp;
-            }
-
-            @Override
-            public Object getValue() {
-                return service.provider.rdn.newValue;
-            }
-        };
+        return new DefaultTimedValue<>(service.provider.rdn.newValue, service.provider.rdn.timestamp);
     }
 
     @Override

--- a/core/api/src/main/java/org/eclipse/sensinact/core/twin/DefaultTimedValue.java
+++ b/core/api/src/main/java/org/eclipse/sensinact/core/twin/DefaultTimedValue.java
@@ -10,25 +10,28 @@
 * Contributors:
 *   Kentyou - initial implementation
 **********************************************************************/
-package org.eclipse.sensinact.core.twin.impl;
+package org.eclipse.sensinact.core.twin;
 
 import java.time.Instant;
 
-import org.eclipse.sensinact.core.twin.TimedValue;
+public record DefaultTimedValue<T> (T value, Instant timestamp) implements TimedValue<T> {
 
-public class TimedValueImpl<T> implements TimedValue<T> {
+    public static final DefaultTimedValue<?> EMPTY = new DefaultTimedValue<>();
 
-    private final Instant timestamp;
-
-    private final T value;
-
-    public TimedValueImpl(final T value) {
-        this(value, Instant.now());
+    /**
+     * A shortcut for creating an empty TimedValue with no value or timestamp
+     * @param value
+     */
+    public DefaultTimedValue() {
+        this(null, null);
     }
 
-    public TimedValueImpl(final T value, Instant instant) {
-        this.value = value;
-        this.timestamp = instant;
+    /**
+     * A shortcut for creating a value with the current time
+     * @param value
+     */
+    public DefaultTimedValue(T value) {
+        this(value, Instant.now());
     }
 
     @Override
@@ -39,10 +42,5 @@ public class TimedValueImpl<T> implements TimedValue<T> {
     @Override
     public T getValue() {
         return value;
-    }
-
-    @Override
-    public String toString() {
-        return String.format("TimedValue(%s, %s)", getValue(), getTimestamp());
     }
 }

--- a/core/api/src/main/java/org/eclipse/sensinact/core/twin/TimedValue.java
+++ b/core/api/src/main/java/org/eclipse/sensinact/core/twin/TimedValue.java
@@ -14,9 +14,20 @@ package org.eclipse.sensinact.core.twin;
 
 import java.time.Instant;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+@JsonDeserialize(as = DefaultTimedValue.class)
 public interface TimedValue<T> {
 
     Instant getTimestamp();
 
     T getValue();
+
+    /**
+     * @return true if this {@link TimedValue} has no timestamp
+     * and is therefore an empty marker value
+     */
+    default boolean isEmpty() {
+        return getTimestamp() == null;
+    }
 }

--- a/core/emf-api/dependency-check.bndrun
+++ b/core/emf-api/dependency-check.bndrun
@@ -1,6 +1,6 @@
 -runrequires: bnd.identity;id='${project.groupId}.${project.artifactId}'
 -runfw: org.apache.felix.framework
--runee: JavaSE-11
+-runee: JavaSE-17
 
 # This blacklist ensures consistent resolution locally and in CI
 -runblacklist: bnd.identity;id='org.osgi.service.cm'

--- a/core/impl/integration-test.bndrun
+++ b/core/impl/integration-test.bndrun
@@ -5,7 +5,7 @@
 	bnd.identity;id='ch.qos.logback.classic'
 -resolve.effective: active
 
--runee: JavaSE-11
+-runee: JavaSE-17
 -runfw: org.apache.felix.framework
 -runproperties: \
 	org.osgi.framework.bootdelegation=org.mockito.internal.creation.bytebuddy.inject,\

--- a/core/impl/src/main/java/org/eclipse/sensinact/core/model/nexus/ModelNexus.java
+++ b/core/impl/src/main/java/org/eclipse/sensinact/core/model/nexus/ModelNexus.java
@@ -59,8 +59,8 @@ import org.eclipse.sensinact.core.model.nexus.emf.EMFUtil;
 import org.eclipse.sensinact.core.model.nexus.emf.NamingUtils;
 import org.eclipse.sensinact.core.model.nexus.emf.compare.EMFCompareUtil;
 import org.eclipse.sensinact.core.notification.impl.NotificationAccumulator;
+import org.eclipse.sensinact.core.twin.DefaultTimedValue;
 import org.eclipse.sensinact.core.twin.TimedValue;
-import org.eclipse.sensinact.core.twin.impl.TimedValueImpl;
 import org.eclipse.sensinact.core.whiteboard.impl.SensinactWhiteboard;
 import org.eclipse.sensinact.model.core.metadata.Action;
 import org.eclipse.sensinact.model.core.metadata.ActionParameter;
@@ -715,13 +715,13 @@ public class ModelNexus {
         if (metadata != null) {
             for (FeatureCustomMetadata entry : metadata.getExtra()) {
                 if (entry.getName().equals(key)) {
-                    return new TimedValueImpl<Object>(entry.getValue(), entry.getTimestamp());
+                    return new DefaultTimedValue<Object>(entry.getValue(), entry.getTimestamp());
                 }
             }
             // If the resource exists but has no metadata for that key then return an
             // empty timed value indicating that the resource exists but the metadata
             // is not set
-            return new TimedValueImpl<Object>(null, null);
+            return new DefaultTimedValue<Object>(null, null);
         }
         return null;
     }

--- a/core/impl/src/main/java/org/eclipse/sensinact/core/twin/impl/SensinactDigitalTwinImpl.java
+++ b/core/impl/src/main/java/org/eclipse/sensinact/core/twin/impl/SensinactDigitalTwinImpl.java
@@ -37,6 +37,7 @@ import org.eclipse.sensinact.core.model.nexus.emf.EMFUtil;
 import org.eclipse.sensinact.core.snapshot.ProviderSnapshot;
 import org.eclipse.sensinact.core.snapshot.ResourceSnapshot;
 import org.eclipse.sensinact.core.snapshot.ServiceSnapshot;
+import org.eclipse.sensinact.core.twin.DefaultTimedValue;
 import org.eclipse.sensinact.core.twin.SensinactResource;
 import org.eclipse.sensinact.core.twin.SensinactService;
 import org.eclipse.sensinact.core.twin.TimedValue;
@@ -267,12 +268,12 @@ public class SensinactDigitalTwinImpl extends CommandScopedImpl implements Sensi
         // Check value type
         final Object rawValue = svc.eGet(rcFeature);
         if (rawValue == null) {
-            return new TimedValueImpl<T>(null, timestamp);
+            return new DefaultTimedValue<T>(null, timestamp);
         } else if (!type.isAssignableFrom(rawValue.getClass())) {
             throw new IllegalArgumentException(
                     "Expected a " + type.getName() + " but resource is a " + rawValue.getClass().getName());
         } else {
-            return new TimedValueImpl<T>(type.cast(rawValue), timestamp);
+            return new DefaultTimedValue<T>(type.cast(rawValue), timestamp);
         }
     }
 
@@ -319,7 +320,7 @@ public class SensinactDigitalTwinImpl extends CommandScopedImpl implements Sensi
         }
 
         rcSnapshot.setValue(
-                new TimedValueImpl<Object>(svc == null ? null : svc.eGet((EStructuralFeature) rcFeature), timestamp));
+                new DefaultTimedValue<Object>(svc == null ? null : svc.eGet((EStructuralFeature) rcFeature), timestamp));
     }
 
     @Override

--- a/core/impl/src/main/java/org/eclipse/sensinact/core/twin/impl/SensinactResourceImpl.java
+++ b/core/impl/src/main/java/org/eclipse/sensinact/core/twin/impl/SensinactResourceImpl.java
@@ -28,6 +28,7 @@ import org.eclipse.sensinact.core.model.ResourceType;
 import org.eclipse.sensinact.core.model.ValueType;
 import org.eclipse.sensinact.core.model.impl.ResourceImpl;
 import org.eclipse.sensinact.core.model.nexus.ModelNexus;
+import org.eclipse.sensinact.core.twin.DefaultTimedValue;
 import org.eclipse.sensinact.core.twin.SensinactResource;
 import org.eclipse.sensinact.core.twin.SensinactService;
 import org.eclipse.sensinact.core.twin.TimedValue;
@@ -126,7 +127,7 @@ public class SensinactResourceImpl extends CommandScopedImpl implements Sensinac
             currentTimestamp = null;
         }
 
-        return new TimedValueImpl<T>(currentValue, currentTimestamp);
+        return new DefaultTimedValue<T>(currentValue, currentTimestamp);
     }
 
     @SuppressWarnings("unchecked")
@@ -152,7 +153,7 @@ public class SensinactResourceImpl extends CommandScopedImpl implements Sensinac
             if (hasExternalSetter) {
                 // Check new value type
                 final TimedValue<?> cachedValue = getValueFromTwin(type);
-                final TimedValue<T> newValue = new TimedValueImpl<T>(value, timestamp);
+                final TimedValue<T> newValue = new DefaultTimedValue<T>(value, timestamp);
                 return modelNexus.pushValue(provider, serviceName, resource, (Class<T>) type,
                         (TimedValue<T>) cachedValue, newValue).map(x -> null);
             } else {

--- a/core/impl/src/main/java/org/eclipse/sensinact/core/whiteboard/impl/GetMethod.java
+++ b/core/impl/src/main/java/org/eclipse/sensinact/core/whiteboard/impl/GetMethod.java
@@ -20,8 +20,8 @@ import java.util.Set;
 import org.eclipse.sensinact.core.annotation.dto.NullAction;
 import org.eclipse.sensinact.core.annotation.verb.GetParam;
 import org.eclipse.sensinact.core.annotation.verb.GetParam.GetSegment;
+import org.eclipse.sensinact.core.twin.DefaultTimedValue;
 import org.eclipse.sensinact.core.twin.TimedValue;
-import org.eclipse.sensinact.core.twin.impl.TimedValueImpl;
 import org.eclipse.sensinact.core.whiteboard.WhiteboardGet;
 import org.osgi.util.promise.Promise;
 import org.osgi.util.promise.PromiseFactory;
@@ -64,14 +64,14 @@ class GetMethod extends AbstractResourceMethod implements WhiteboardGet<Object> 
                     return pf.resolved(null);
                 case UPDATE_IF_PRESENT:
                     return pf.resolved(cachedValue == null || cachedValue.getTimestamp() == null ? null
-                            : new TimedValueImpl<Object>(null));
+                            : new DefaultTimedValue<Object>(null));
                 case UPDATE:
-                    return pf.resolved(new TimedValueImpl<Object>(null));
+                    return pf.resolved(new DefaultTimedValue<Object>(null));
                 default:
                     return pf.failed(new IllegalArgumentException("Unknown null action: " + nullAction));
                 }
             } else if (resourceType.isAssignableFrom(result.getClass())) {
-                return pf.resolved(new TimedValueImpl<Object>(resourceType.cast(result)));
+                return pf.resolved(new DefaultTimedValue<Object>(resourceType.cast(result)));
             } else {
                 return pf.failed(new Exception("Invalid result type: " + result.getClass()));
             }

--- a/core/impl/src/main/java/org/eclipse/sensinact/core/whiteboard/impl/SetMethod.java
+++ b/core/impl/src/main/java/org/eclipse/sensinact/core/whiteboard/impl/SetMethod.java
@@ -19,8 +19,8 @@ import java.util.Set;
 
 import org.eclipse.sensinact.core.annotation.verb.SetParam;
 import org.eclipse.sensinact.core.annotation.verb.SetParam.SetSegment;
+import org.eclipse.sensinact.core.twin.DefaultTimedValue;
 import org.eclipse.sensinact.core.twin.TimedValue;
-import org.eclipse.sensinact.core.twin.impl.TimedValueImpl;
 import org.eclipse.sensinact.core.whiteboard.WhiteboardSet;
 import org.osgi.util.promise.Promise;
 import org.osgi.util.promise.PromiseFactory;
@@ -51,7 +51,7 @@ class SetMethod extends AbstractResourceMethod implements WhiteboardSet<Object> 
             } else if (o == null) {
                 return pf.resolved(null);
             } else if (resourceType.isAssignableFrom(o.getClass())) {
-                return pf.resolved(new TimedValueImpl<Object>(resourceType.cast(o)));
+                return pf.resolved(new DefaultTimedValue<Object>(resourceType.cast(o)));
             } else {
                 return pf.failed(new Exception("Invalid result type: " + o.getClass()));
             }

--- a/core/impl/src/test/java/org/eclipse/sensinact/core/command/impl/WhiteboardImplTest.java
+++ b/core/impl/src/test/java/org/eclipse/sensinact/core/command/impl/WhiteboardImplTest.java
@@ -61,12 +61,12 @@ import org.eclipse.sensinact.core.model.Resource;
 import org.eclipse.sensinact.core.model.ResourceBuilder;
 import org.eclipse.sensinact.core.model.SensinactModelManager;
 import org.eclipse.sensinact.core.model.Service;
+import org.eclipse.sensinact.core.twin.DefaultTimedValue;
 import org.eclipse.sensinact.core.twin.SensinactDigitalTwin;
 import org.eclipse.sensinact.core.twin.SensinactProvider;
 import org.eclipse.sensinact.core.twin.SensinactResource;
 import org.eclipse.sensinact.core.twin.SensinactService;
 import org.eclipse.sensinact.core.twin.TimedValue;
-import org.eclipse.sensinact.core.twin.impl.TimedValueImpl;
 import org.eclipse.sensinact.core.whiteboard.AbstractDescriptiveAct;
 import org.eclipse.sensinact.core.whiteboard.AbstractDescriptiveReadOnly;
 import org.eclipse.sensinact.core.whiteboard.AbstractDescriptiveReadWrite;
@@ -569,7 +569,7 @@ public class WhiteboardImplTest {
                 break;
             }
 
-            return new TimedValueImpl<String>(value, newValue.getTimestamp());
+            return new DefaultTimedValue<String>(value, newValue.getTimestamp());
         }
     }
 
@@ -644,7 +644,7 @@ public class WhiteboardImplTest {
                 content.oldValue = null;
                 content.newValue = resource;
             }
-            return new TimedValueImpl<Content>(content,
+            return new DefaultTimedValue<Content>(content,
                     cached.getTimestamp() == null ? Instant.now() : cached.getTimestamp());
         }
 
@@ -656,7 +656,7 @@ public class WhiteboardImplTest {
             Content content = new Content();
             content.oldValue = cached.getValue() != null ? cached.getValue().newValue : null;
             content.newValue = newValue.getValue();
-            return new TimedValueImpl<Content>(content, newValue.getTimestamp());
+            return new DefaultTimedValue<Content>(content, newValue.getTimestamp());
         }
     }
 
@@ -771,7 +771,7 @@ public class WhiteboardImplTest {
                 @Override
                 public Promise<TimedValue<Integer>> doPullValue(PromiseFactory pf, String modelPackageUri, String model,
                         String provider, String service, String resource, TimedValue<Integer> cachedValue) {
-                    return pf.resolved(new TimedValueImpl<>(42));
+                    return pf.resolved(new DefaultTimedValue<>(42));
                 }
             };
 
@@ -801,7 +801,7 @@ public class WhiteboardImplTest {
                 @Override
                 public Promise<TimedValue<Long>> doPullValue(PromiseFactory pf, String modelPackageUri, String model,
                         String provider, String service, String resource, TimedValue<Long> cachedValue) {
-                    return pf.resolved(new TimedValueImpl<Long>(value));
+                    return pf.resolved(new DefaultTimedValue<Long>(value));
                 }
 
                 @Override
@@ -809,7 +809,7 @@ public class WhiteboardImplTest {
                         String provider, String service, String resource, TimedValue<Long> cachedValue,
                         TimedValue<Long> newValue) {
                     this.value = newValue.getValue();
-                    return pf.resolved(new TimedValueImpl<Long>(value));
+                    return pf.resolved(new DefaultTimedValue<Long>(value));
                 }
             };
 
@@ -977,7 +977,7 @@ public class WhiteboardImplTest {
         @Test
         void testReadOnly() throws Throwable {
             WhiteboardGet<Integer> getHandler = (pf, modelPackageUri, model, provider, service, resource, resourceType,
-                    cachedValue) -> pf.resolved(new TimedValueImpl<>(42));
+                    cachedValue) -> pf.resolved(new DefaultTimedValue<>(42));
 
             final String modelName = "wbHandlerROTest";
             final String svcName = "svc";
@@ -1011,7 +1011,7 @@ public class WhiteboardImplTest {
                 public Promise<TimedValue<Long>> pullValue(PromiseFactory pf, String modelPackageUri, String model,
                         String provider, String service, String resource, Class<Long> resourceType,
                         TimedValue<Long> cachedValue) {
-                    return pf.resolved(new TimedValueImpl<Long>(value));
+                    return pf.resolved(new DefaultTimedValue<Long>(value));
                 }
 
                 @Override
@@ -1019,7 +1019,7 @@ public class WhiteboardImplTest {
                         String provider, String service, String resource, Class<Long> resourceType,
                         TimedValue<Long> cachedValue, TimedValue<Long> newValue) {
                     this.value = newValue.getValue();
-                    return pf.resolved(new TimedValueImpl<Long>(value));
+                    return pf.resolved(new DefaultTimedValue<Long>(value));
                 }
             };
 
@@ -1177,9 +1177,9 @@ public class WhiteboardImplTest {
         @Test
         void testHandlersProviderFilter() throws Throwable {
             WhiteboardGet<Integer> h1 = (pf, modelPackageUri, model, provider, service, resource, resourceType,
-                    cachedValue) -> pf.resolved(new TimedValueImpl<>(1));
+                    cachedValue) -> pf.resolved(new DefaultTimedValue<>(1));
             WhiteboardGet<Integer> h2 = (pf, modelPackageUri, model, provider, service, resource, resourceType,
-                    cachedValue) -> pf.resolved(new TimedValueImpl<>(2));
+                    cachedValue) -> pf.resolved(new DefaultTimedValue<>(2));
 
             final String modelName = "wbHandlerPriority";
             final String svcName = "svc";
@@ -1242,11 +1242,11 @@ public class WhiteboardImplTest {
         @Test
         void testHandlersWildcardFilter() throws Throwable {
             WhiteboardGet<Integer> h1 = (pf, modelPackageUri, model, provider, service, resource, resourceType,
-                    cachedValue) -> pf.resolved(new TimedValueImpl<>(1));
+                    cachedValue) -> pf.resolved(new DefaultTimedValue<>(1));
             WhiteboardGet<Integer> h2 = (pf, modelPackageUri, model, provider, service, resource, resourceType,
-                    cachedValue) -> pf.resolved(new TimedValueImpl<>(2));
+                    cachedValue) -> pf.resolved(new DefaultTimedValue<>(2));
             WhiteboardGet<Integer> h3 = (pf, modelPackageUri, model, provider, service, resource, resourceType,
-                    cachedValue) -> pf.resolved(new TimedValueImpl<>(3));
+                    cachedValue) -> pf.resolved(new DefaultTimedValue<>(3));
 
             final String modelName = "wbHandlerPriority";
             final String svcName1 = "svc1";

--- a/distribution/launcher/export.bndrun
+++ b/distribution/launcher/export.bndrun
@@ -1,4 +1,4 @@
--runee: JavaSE-11
+-runee: JavaSE-17
 -runrequires: \
 	bnd.identity;id='org.eclipse.sensinact.gateway.distribution.launcher',\
 	bnd.identity;id='org.apache.aries.spifly.dynamic.framework.extension',\

--- a/filters/ldap/integration-test.bndrun
+++ b/filters/ldap/integration-test.bndrun
@@ -7,7 +7,7 @@
 	bnd.identity;id='ch.qos.logback.classic'
 -resolve.effective: active
 
--runee: JavaSE-11
+-runee: JavaSE-17
 -runfw: org.apache.felix.framework
 -runproperties: logback.configurationFile=${project.build.testOutputDirectory}/logback-test.xml
 

--- a/filters/ldap/src/test/java/org/eclipse/sensinact/filters/ldap/LdapParserTest.java
+++ b/filters/ldap/src/test/java/org/eclipse/sensinact/filters/ldap/LdapParserTest.java
@@ -31,6 +31,7 @@ import org.eclipse.sensinact.core.snapshot.ProviderSnapshot;
 import org.eclipse.sensinact.core.snapshot.ResourceSnapshot;
 import org.eclipse.sensinact.core.snapshot.ResourceValueFilter;
 import org.eclipse.sensinact.core.snapshot.ServiceSnapshot;
+import org.eclipse.sensinact.core.twin.DefaultTimedValue;
 import org.eclipse.sensinact.core.twin.TimedValue;
 import org.eclipse.sensinact.filters.ldap.antlr.impl.FilterVisitor;
 import org.eclipse.sensinact.filters.ldap.antlr.impl.ILdapCriterion;
@@ -77,17 +78,7 @@ public class LdapParserTest {
 
             @Override
             public TimedValue<?> getValue() {
-                return new TimedValue<Object>() {
-                    @Override
-                    public Instant getTimestamp() {
-                        return Instant.now();
-                    }
-
-                    @Override
-                    public Object getValue() {
-                        return value;
-                    }
-                };
+                return new DefaultTimedValue<>(value);
             }
 
             @Override

--- a/filters/resource.selector.impl/src/test/java/org/eclipse/sensinact/filters/resource/selector/impl/ResourceSelectorTest.java
+++ b/filters/resource.selector.impl/src/test/java/org/eclipse/sensinact/filters/resource/selector/impl/ResourceSelectorTest.java
@@ -30,6 +30,7 @@ import org.eclipse.sensinact.core.snapshot.ProviderSnapshot;
 import org.eclipse.sensinact.core.snapshot.ResourceSnapshot;
 import org.eclipse.sensinact.core.snapshot.ResourceValueFilter;
 import org.eclipse.sensinact.core.snapshot.ServiceSnapshot;
+import org.eclipse.sensinact.core.twin.DefaultTimedValue;
 import org.eclipse.sensinact.core.twin.TimedValue;
 import org.eclipse.sensinact.filters.resource.selector.api.ResourceSelector;
 import org.eclipse.sensinact.filters.resource.selector.api.Selection;
@@ -63,17 +64,7 @@ public class ResourceSelectorTest {
 
             @Override
             public TimedValue<?> getValue() {
-                return new TimedValue<Object>() {
-                    @Override
-                    public Instant getTimestamp() {
-                        return Instant.now();
-                    }
-
-                    @Override
-                    public Object getValue() {
-                        return value;
-                    }
-                };
+                return new DefaultTimedValue<>(value);
             }
 
             @Override

--- a/northbound/query-handler/integration-test.bndrun
+++ b/northbound/query-handler/integration-test.bndrun
@@ -5,7 +5,7 @@
 	bnd.identity;id='ch.qos.logback.classic'
 -resolve.effective: active
 
--runee: JavaSE-11
+-runee: JavaSE-17
 -runfw: org.apache.felix.framework
 -runproperties: logback.configurationFile=${project.build.testOutputDirectory}/logback-test.xml
 

--- a/northbound/rest/integration-test.bndrun
+++ b/northbound/rest/integration-test.bndrun
@@ -13,7 +13,7 @@
 
 -resolve.effective: active
 
--runee: JavaSE-11
+-runee: JavaSE-17
 -runfw: org.apache.felix.framework
 -runproperties: logback.configurationFile=${project.build.testOutputDirectory}/logback-test.xml
 

--- a/northbound/security/openid-connect/integration-test.bndrun
+++ b/northbound/security/openid-connect/integration-test.bndrun
@@ -6,7 +6,7 @@
 	bnd.identity;id='ch.qos.logback.classic'
 -resolve.effective: active
 
--runee: JavaSE-11
+-runee: JavaSE-17
 -runfw: org.apache.felix.framework
 -runproperties: \
 	org.osgi.framework.bootdelegation=org.mockito.internal.creation.bytebuddy.inject,\

--- a/northbound/sensorthings/filter/src/test/java/org/eclipse/sensinact/northbound/filters/sensorthings/RcUtils.java
+++ b/northbound/sensorthings/filter/src/test/java/org/eclipse/sensinact/northbound/filters/sensorthings/RcUtils.java
@@ -22,6 +22,7 @@ import org.eclipse.sensinact.core.model.ValueType;
 import org.eclipse.sensinact.core.snapshot.ProviderSnapshot;
 import org.eclipse.sensinact.core.snapshot.ResourceSnapshot;
 import org.eclipse.sensinact.core.snapshot.ServiceSnapshot;
+import org.eclipse.sensinact.core.twin.DefaultTimedValue;
 import org.eclipse.sensinact.core.twin.TimedValue;
 
 /**
@@ -144,22 +145,7 @@ public class RcUtils {
 
             @Override
             public TimedValue<?> getValue() {
-                return new TimedValue<Object>() {
-                    @Override
-                    public Instant getTimestamp() {
-                        return rcTime;
-                    }
-
-                    @Override
-                    public Object getValue() {
-                        return value;
-                    }
-
-                    @Override
-                    public String toString() {
-                        return String.format("%s (%s)", value, rcTime);
-                    }
-                };
+                return new DefaultTimedValue<>(value, rcTime);
             }
 
             @Override

--- a/northbound/sensorthings/mqtt/integration-test.bndrun
+++ b/northbound/sensorthings/mqtt/integration-test.bndrun
@@ -7,7 +7,7 @@
 
 -resolve.effective: active
 
--runee: JavaSE-11
+-runee: JavaSE-17
 -runfw: org.apache.felix.framework
 -runproperties: logback.configurationFile=${project.build.testOutputDirectory}/logback-test.xml
 

--- a/northbound/sensorthings/mqtt/src/main/java/org/eclipse/sensinact/gateway/northbount/sensorthings/mqtt/mappers/DtoMapper.java
+++ b/northbound/sensorthings/mqtt/src/main/java/org/eclipse/sensinact/gateway/northbount/sensorthings/mqtt/mappers/DtoMapper.java
@@ -20,6 +20,7 @@ import java.util.Optional;
 import org.eclipse.sensinact.core.snapshot.ProviderSnapshot;
 import org.eclipse.sensinact.core.snapshot.ResourceSnapshot;
 import org.eclipse.sensinact.core.snapshot.ServiceSnapshot;
+import org.eclipse.sensinact.core.twin.DefaultTimedValue;
 import org.eclipse.sensinact.core.twin.TimedValue;
 import org.eclipse.sensinact.gateway.geojson.Coordinates;
 import org.eclipse.sensinact.gateway.geojson.Feature;
@@ -263,17 +264,7 @@ public class DtoMapper {
             }
         }
 
-        return new TimedValue<GeoJsonObject>() {
-            @Override
-            public Instant getTimestamp() {
-                return time;
-            }
-
-            @Override
-            public GeoJsonObject getValue() {
-                return parsedLocation;
-            }
-        };
+        return new DefaultTimedValue<>(parsedLocation, time);
     }
 
     public static FeatureOfInterest toFeatureOfInterest(ObjectMapper mapper, ProviderSnapshot provider) {

--- a/northbound/sensorthings/mqtt/src/main/java/org/eclipse/sensinact/gateway/northbount/sensorthings/mqtt/mappers/ObservationsMapper.java
+++ b/northbound/sensorthings/mqtt/src/main/java/org/eclipse/sensinact/gateway/northbount/sensorthings/mqtt/mappers/ObservationsMapper.java
@@ -12,11 +12,11 @@
 **********************************************************************/
 package org.eclipse.sensinact.gateway.northbount.sensorthings.mqtt.mappers;
 
-import java.time.Instant;
 import java.util.stream.Stream;
 
 import org.eclipse.sensinact.core.command.GatewayThread;
 import org.eclipse.sensinact.core.notification.ResourceDataNotification;
+import org.eclipse.sensinact.core.twin.DefaultTimedValue;
 import org.eclipse.sensinact.core.twin.TimedValue;
 import org.eclipse.sensinact.gateway.northbount.sensorthings.mqtt.SensorthingsMapper;
 import org.eclipse.sensinact.sensorthings.sensing.dto.Observation;
@@ -31,19 +31,7 @@ public class ObservationsMapper extends SensorthingsMapper<Observation> {
     }
 
     public Promise<Stream<Observation>> toPayload(ResourceDataNotification notification) {
-        TimedValue<Object> tv = new TimedValue<Object>() {
-
-            @Override
-            public Instant getTimestamp() {
-                return notification.timestamp;
-            }
-
-            @Override
-            public Object getValue() {
-                return notification.newValue;
-            }
-
-        };
+        TimedValue<Object> tv = new DefaultTimedValue<>(notification.newValue, notification.timestamp);
         return wrap(DtoMapper.toObservation(notification.provider, notification.service, notification.resource, tv));
     }
 

--- a/northbound/sensorthings/rest.gateway/integration-test.bndrun
+++ b/northbound/sensorthings/rest.gateway/integration-test.bndrun
@@ -12,7 +12,7 @@
 
 -resolve.effective: active
 
--runee: JavaSE-11
+-runee: JavaSE-17
 -runfw: org.apache.felix.framework
 -runproperties: logback.configurationFile=${project.build.testOutputDirectory}/logback-test.xml
 

--- a/northbound/sensorthings/rest.gateway/src/main/java/org/eclipse/sensinact/sensorthings/sensing/rest/impl/DtoMapper.java
+++ b/northbound/sensorthings/rest.gateway/src/main/java/org/eclipse/sensinact/sensorthings/sensing/rest/impl/DtoMapper.java
@@ -31,6 +31,7 @@ import java.util.Optional;
 import org.eclipse.sensinact.core.snapshot.ProviderSnapshot;
 import org.eclipse.sensinact.core.snapshot.ResourceSnapshot;
 import org.eclipse.sensinact.core.snapshot.ServiceSnapshot;
+import org.eclipse.sensinact.core.twin.DefaultTimedValue;
 import org.eclipse.sensinact.core.twin.TimedValue;
 import org.eclipse.sensinact.gateway.geojson.Coordinates;
 import org.eclipse.sensinact.gateway.geojson.Feature;
@@ -565,17 +566,7 @@ public class DtoMapper {
             }
         }
 
-        return new TimedValue<GeoJsonObject>() {
-            @Override
-            public Instant getTimestamp() {
-                return time;
-            }
-
-            @Override
-            public GeoJsonObject getValue() {
-                return parsedLocation;
-            }
-        };
+        return new DefaultTimedValue<>(parsedLocation, time);
     }
 
 }

--- a/northbound/session/session-impl/integration-test.bndrun
+++ b/northbound/session/session-impl/integration-test.bndrun
@@ -5,7 +5,7 @@
 	bnd.identity;id='ch.qos.logback.classic'
 -resolve.effective: active
 
--runee: JavaSE-11
+-runee: JavaSE-17
 -runfw: org.apache.felix.framework
 -runproperties: \
 	org.osgi.framework.bootdelegation=org.mockito.internal.creation.bytebuddy.inject,\

--- a/northbound/websocket/integration-test.bndrun
+++ b/northbound/websocket/integration-test.bndrun
@@ -9,7 +9,7 @@
 	bnd.identity;id='ch.qos.logback.classic'
 -resolve.effective: active
 
--runee: JavaSE-11
+-runee: JavaSE-17
 -runfw: org.apache.felix.framework
 -runproperties: logback.configurationFile=${project.build.testOutputDirectory}/logback-test.xml
 

--- a/northbound/websocket/src/main/java/org/eclipse/sensinact/northbound/ws/impl/NotificationSnapshot.java
+++ b/northbound/websocket/src/main/java/org/eclipse/sensinact/northbound/ws/impl/NotificationSnapshot.java
@@ -24,6 +24,7 @@ import org.eclipse.sensinact.core.notification.ResourceDataNotification;
 import org.eclipse.sensinact.core.snapshot.ProviderSnapshot;
 import org.eclipse.sensinact.core.snapshot.ResourceSnapshot;
 import org.eclipse.sensinact.core.snapshot.ServiceSnapshot;
+import org.eclipse.sensinact.core.twin.DefaultTimedValue;
 import org.eclipse.sensinact.core.twin.TimedValue;
 
 /**
@@ -170,17 +171,7 @@ class NotificationSnapshot {
         private final TimedValue<?> value;
 
         public ResourceSnapshotImpl(final Object value) {
-            this.value = new TimedValue<Object>() {
-                @Override
-                public Instant getTimestamp() {
-                    return timestamp;
-                }
-
-                @Override
-                public Object getValue() {
-                    return value;
-                }
-            };
+            this.value = new DefaultTimedValue<>(value, timestamp);
         }
 
         @Override

--- a/pom.xml
+++ b/pom.xml
@@ -107,9 +107,9 @@
 
   <properties>
     <!-- Build properties -->
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
-    <maven.compiler.release>11</maven.compiler.release>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.release>17</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <revision>0.0.2</revision>
     <changelist>-SNAPSHOT</changelist>

--- a/southbound/history/timescale-provider/integration-test.bndrun
+++ b/southbound/history/timescale-provider/integration-test.bndrun
@@ -6,7 +6,7 @@
 	bnd.identity;id='ch.qos.logback.classic'
 -resolve.effective: active
 
--runee: JavaSE-11
+-runee: JavaSE-17
 -runfw: org.apache.felix.framework
 -runproperties: logback.configurationFile=${project.build.testOutputDirectory}/logback-test.xml
 

--- a/southbound/history/timescale-provider/src/main/java/org/eclipse/sensinact/gateway/southbound/history/timescale/TimescaleDatabaseWorker.java
+++ b/southbound/history/timescale-provider/src/main/java/org/eclipse/sensinact/gateway/southbound/history/timescale/TimescaleDatabaseWorker.java
@@ -28,6 +28,7 @@ import java.util.function.Supplier;
 
 import org.eclipse.sensinact.core.notification.ResourceDataNotification;
 import org.eclipse.sensinact.core.snapshot.ICriterion;
+import org.eclipse.sensinact.core.twin.DefaultTimedValue;
 import org.eclipse.sensinact.core.twin.TimedValue;
 import org.eclipse.sensinact.gateway.geojson.GeoJsonObject;
 import org.eclipse.sensinact.gateway.southbound.history.api.HistoricalQueries;
@@ -254,7 +255,7 @@ public class TimescaleDatabaseWorker implements TypedEventHandler<ResourceDataNo
                 if (rs.next()) {
                     result = toTimedValue(rs);
                 } else {
-                    result = new TimedValueImpl<>(null, null);
+                    result = new DefaultTimedValue<>();
                 }
                 return result;
             });
@@ -296,7 +297,7 @@ public class TimescaleDatabaseWorker implements TypedEventHandler<ResourceDataNo
                 }
             }
         }
-        return new TimedValueImpl<>(value, dataTime);
+        return new DefaultTimedValue<>(value, dataTime);
     }
 
     @Override
@@ -344,7 +345,7 @@ public class TimescaleDatabaseWorker implements TypedEventHandler<ResourceDataNo
                     }
                 }
                 if (rs.next()) {
-                    list.add(new TimedValueImpl<>(null, null));
+                    list.add(DefaultTimedValue.EMPTY);
                 }
 
                 return list;
@@ -398,35 +399,4 @@ public class TimescaleDatabaseWorker implements TypedEventHandler<ResourceDataNo
         }
     }
 
-}
-
-class TimedValueImpl<T> implements TimedValue<T> {
-
-    private final Instant timestamp;
-
-    private final T value;
-
-    public TimedValueImpl(final T value) {
-        this(value, Instant.now());
-    }
-
-    public TimedValueImpl(final T value, Instant instant) {
-        this.value = value;
-        this.timestamp = instant;
-    }
-
-    @Override
-    public Instant getTimestamp() {
-        return timestamp;
-    }
-
-    @Override
-    public T getValue() {
-        return value;
-    }
-
-    @Override
-    public String toString() {
-        return String.format("TimedValue(%s, %s)", getValue(), getTimestamp());
-    }
 }

--- a/southbound/http/http-callback-whiteboard/integration-test.bndrun
+++ b/southbound/http/http-callback-whiteboard/integration-test.bndrun
@@ -6,7 +6,7 @@
 	bnd.identity;id='ch.qos.logback.classic'
 -resolve.effective: active
 
--runee: JavaSE-11
+-runee: JavaSE-17
 -runfw: org.apache.felix.framework
 -runproperties: \
 	org.osgi.service.http.port=-1,\

--- a/southbound/http/http-device-factory/integration-test.bndrun
+++ b/southbound/http/http-device-factory/integration-test.bndrun
@@ -12,7 +12,7 @@
 	bnd.identity;id='ch.qos.logback.classic'
 -resolve.effective: active
 
--runee: JavaSE-11
+-runee: JavaSE-17
 -runfw: org.apache.felix.framework
 
 # This will help us keep -runbundles sorted

--- a/southbound/mqtt/mqtt-device-factory/integration-test.bndrun
+++ b/southbound/mqtt/mqtt-device-factory/integration-test.bndrun
@@ -9,7 +9,7 @@
 	bnd.identity;id='ch.qos.logback.classic'
 -resolve.effective: active
 
--runee: JavaSE-11
+-runee: JavaSE-17
 -runfw: org.apache.felix.framework
 -runproperties: logback.configurationFile=${project.build.testOutputDirectory}/logback-test.xml
 

--- a/southbound/virtual/virtual-temperature-sensor/integration-test.bndrun
+++ b/southbound/virtual/virtual-temperature-sensor/integration-test.bndrun
@@ -5,7 +5,7 @@
 	bnd.identity;id='ch.qos.logback.classic'
 -resolve.effective: active
 
--runee: JavaSE-11
+-runee: JavaSE-17
 -runfw: org.apache.felix.framework
 -runproperties: logback.configurationFile=${project.build.testOutputDirectory}/logback-test.xml
 

--- a/southbound/wot/core/integration-test.bndrun
+++ b/southbound/wot/core/integration-test.bndrun
@@ -6,7 +6,7 @@
 	bnd.identity;id='ch.qos.logback.classic'
 -resolve.effective: active
 
--runee: JavaSE-11
+-runee: JavaSE-17
 -runfw: org.apache.felix.framework
 -runproperties: \
 	org.osgi.service.http.port=-1,\

--- a/southbound/wot/http/integration-test.bndrun
+++ b/southbound/wot/http/integration-test.bndrun
@@ -6,7 +6,7 @@
 	bnd.identity;id='ch.qos.logback.classic'
 -resolve.effective: active
 
--runee: JavaSE-11
+-runee: JavaSE-17
 -runfw: org.apache.felix.framework
 -runproperties: \
 	org.osgi.service.http.port=-1,\


### PR DESCRIPTION
The TimedValue interface is an important part of the API, but I noticed an increasing number of _minimal_ implementations that duplicated one another. This isn't a good sign, and means that we should provide a default implementation. As TimedValue is supposed to be immutable and DTO-like this seems like a good time to move to Java 17 and implement the default as a record type. This keeps the API package clean and simple, while allowing us to continue using the TimedValue interface in the API. Where people want or need to create their own TimedValue implementations they can, but the record implementation should serve for most use cases.