### PR TITLE
Ensure proper JSON serialization of the default timed value implementation

### DIFF
--- a/core/api/pom.xml
+++ b/core/api/pom.xml
@@ -40,6 +40,13 @@
       <artifactId>geo-json</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!-- Test dependencies -->
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+      <version>${jackson.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/core/api/src/main/java/org/eclipse/sensinact/core/twin/DefaultTimedValue.java
+++ b/core/api/src/main/java/org/eclipse/sensinact/core/twin/DefaultTimedValue.java
@@ -1,5 +1,5 @@
 /*********************************************************************
-* Copyright (c) 2022 Contributors to the Eclipse Foundation.
+* Copyright (c) 2025 Contributors to the Eclipse Foundation.
 *
 * This program and the accompanying materials are made
 * available under the terms of the Eclipse Public License 2.0
@@ -14,6 +14,8 @@ package org.eclipse.sensinact.core.twin;
 
 import java.time.Instant;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 public record DefaultTimedValue<T> (T value, Instant timestamp) implements TimedValue<T> {
 
     public static final DefaultTimedValue<?> EMPTY = new DefaultTimedValue<>();
@@ -22,6 +24,7 @@ public record DefaultTimedValue<T> (T value, Instant timestamp) implements Timed
      * A shortcut for creating an empty TimedValue with no value or timestamp
      * @param value
      */
+    @JsonIgnore
     public DefaultTimedValue() {
         this(null, null);
     }
@@ -30,6 +33,7 @@ public record DefaultTimedValue<T> (T value, Instant timestamp) implements Timed
      * A shortcut for creating a value with the current time
      * @param value
      */
+    @JsonIgnore
     public DefaultTimedValue(T value) {
         this(value, Instant.now());
     }

--- a/core/api/src/main/java/org/eclipse/sensinact/core/twin/TimedValue.java
+++ b/core/api/src/main/java/org/eclipse/sensinact/core/twin/TimedValue.java
@@ -14,6 +14,7 @@ package org.eclipse.sensinact.core.twin;
 
 import java.time.Instant;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 @JsonDeserialize(as = DefaultTimedValue.class)
@@ -27,6 +28,7 @@ public interface TimedValue<T> {
      * @return true if this {@link TimedValue} has no timestamp
      * and is therefore an empty marker value
      */
+    @JsonIgnore
     default boolean isEmpty() {
         return getTimestamp() == null;
     }

--- a/core/api/src/test/java/org/eclipse/sensinact/core/twin/DefaultTimedValueTest.java
+++ b/core/api/src/test/java/org/eclipse/sensinact/core/twin/DefaultTimedValueTest.java
@@ -1,0 +1,103 @@
+/*********************************************************************
+* Copyright (c) 2025 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   Kentyou - initial implementation
+**********************************************************************/
+package org.eclipse.sensinact.core.twin;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.Instant;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeType;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+public class DefaultTimedValueTest {
+
+    private static final Instant TIME = Instant.parse("2025-01-23T11:30:15.123Z");
+    private ObjectMapper mapper;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        mapper = JsonMapper.builder().addModule(new JavaTimeModule())
+                .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
+                .build();
+    }
+
+    @Test
+    void testStringValue() throws Exception {
+        TimedValue<String> tv = new DefaultTimedValue<>("test", TIME);
+
+        assertEquals("test", tv.getValue());
+        assertEquals(TIME, tv.getTimestamp());
+
+        JsonNode node = mapper.convertValue(tv, JsonNode.class);
+        assertEquals(JsonNodeType.OBJECT, node.getNodeType());
+        assertEquals(2, node.properties().size());
+        assertEquals("test", node.get("value").asText());
+        assertEquals(TIME.toString(), node.get("timestamp").asText());
+
+        TimedValue<String> copy = mapper.convertValue(node,
+                new TypeReference<TimedValue<String>>() {});
+
+        assertEquals(tv.getValue(), copy.getValue());
+        assertEquals(tv.getTimestamp(), copy.getTimestamp());
+    }
+
+    @Test
+    void testNumberValue() throws Exception {
+        TimedValue<Integer> tv = new DefaultTimedValue<>(5, TIME);
+
+        assertEquals(5, tv.getValue());
+        assertEquals(TIME, tv.getTimestamp());
+
+        JsonNode node = mapper.convertValue(tv, JsonNode.class);
+        assertEquals(JsonNodeType.OBJECT, node.getNodeType());
+        assertEquals(2, node.properties().size());
+        assertEquals(5, node.get("value").asInt());
+        assertEquals(TIME.toString(), node.get("timestamp").asText());
+
+        TimedValue<Integer> copy = mapper.convertValue(node,
+                new TypeReference<TimedValue<Integer>>() {});
+
+        assertEquals(tv.getValue(), copy.getValue());
+        assertEquals(tv.getTimestamp(), copy.getTimestamp());
+    }
+
+    @Test
+    void testValueConversion() throws Exception {
+        TimedValue<String> tv = new DefaultTimedValue<>("5", TIME);
+
+        assertEquals("5", tv.getValue());
+        assertEquals(TIME, tv.getTimestamp());
+
+        JsonNode node = mapper.convertValue(tv, JsonNode.class);
+        assertEquals(JsonNodeType.OBJECT, node.getNodeType());
+        assertEquals(2, node.properties().size());
+        assertEquals(JsonNodeType.STRING, node.get("value").getNodeType());
+        assertEquals("5", node.get("value").asText());
+        assertEquals(TIME.toString(), node.get("timestamp").asText());
+
+        TimedValue<Integer> copy = mapper.convertValue(node,
+                new TypeReference<TimedValue<Integer>>() {});
+
+        assertEquals(Integer.parseInt(tv.getValue()), copy.getValue());
+        assertEquals(tv.getTimestamp(), copy.getTimestamp());
+    }
+
+}


### PR DESCRIPTION
We must mark the extra constructors as ignored, and also the isEmpty property which is not part of the data. Tests added to ensure compatability going forward