### PR TITLE
Update to Aries Typed Event 1.0.0

### DIFF
--- a/core/impl/integration-test.bndrun
+++ b/core/impl/integration-test.bndrun
@@ -34,7 +34,7 @@
 	net.bytebuddy.byte-buddy-agent;version='[1.14.11,1.14.12)',\
 	org.apache.aries.component-dsl.component-dsl;version='[1.2.2,1.2.3)',\
 	org.apache.aries.spifly.dynamic.framework.extension;version='[1.3.7,1.3.8)',\
-	org.apache.aries.typedevent.bus;version='[0.0.2,0.0.3)',\
+	org.apache.aries.typedevent.bus;version='[1.0.0,1.0.1)',\
 	org.apache.felix.configadmin;version='[1.9.24,1.9.25)',\
 	org.apache.felix.scr;version='[2.2.2,2.2.3)',\
 	org.eclipse.emf.common;version='[2.29.0,2.29.1)',\
@@ -54,7 +54,6 @@
 	org.mockito.mockito-core;version='[5.10.0,5.10.1)',\
 	org.objenesis;version='[3.3.0,3.3.1)',\
 	org.opentest4j;version='[1.3.0,1.3.1)',\
-	org.osgi.service.cm;version='[1.6.1,1.6.2)',\
 	org.osgi.service.component;version='[1.5.0,1.5.1)',\
 	org.osgi.service.typedevent;version='[1.0.0,1.0.1)',\
 	org.osgi.test.common;version='[1.3.0,1.3.1)',\

--- a/filters/ldap/integration-test.bndrun
+++ b/filters/ldap/integration-test.bndrun
@@ -31,7 +31,7 @@
 	org.antlr.antlr4-runtime;version='[4.12.0,4.12.1)',\
 	org.apache.aries.component-dsl.component-dsl;version='[1.2.2,1.2.3)',\
 	org.apache.aries.spifly.dynamic.framework.extension;version='[1.3.7,1.3.8)',\
-	org.apache.aries.typedevent.bus;version='[0.0.2,0.0.3)',\
+	org.apache.aries.typedevent.bus;version='[1.0.0,1.0.1)',\
 	org.apache.felix.configadmin;version='[1.9.24,1.9.25)',\
 	org.apache.felix.scr;version='[2.2.2,2.2.3)',\
 	org.eclipse.emf.common;version='[2.29.0,2.29.1)',\
@@ -49,7 +49,6 @@
 	org.eclipse.sensinact.gateway.filters.ldap-tests;version='[0.0.2,0.0.3)',\
 	org.gecko.emf.osgi.component.minimal;version='[6.3.0,6.3.1)',\
 	org.opentest4j;version='[1.3.0,1.3.1)',\
-	org.osgi.service.cm;version='[1.6.1,1.6.2)',\
 	org.osgi.service.component;version='[1.5.0,1.5.1)',\
 	org.osgi.service.typedevent;version='[1.0.0,1.0.1)',\
 	org.osgi.test.common;version='[1.3.0,1.3.1)',\

--- a/filters/resource.selector.impl/integration-test.bndrun
+++ b/filters/resource.selector.impl/integration-test.bndrun
@@ -30,7 +30,7 @@
 	junit-platform-launcher;version='[1.10.1,1.10.2)',\
 	org.apache.aries.component-dsl.component-dsl;version='[1.2.2,1.2.3)',\
 	org.apache.aries.spifly.dynamic.framework.extension;version='[1.3.7,1.3.8)',\
-	org.apache.aries.typedevent.bus;version='[0.0.2,0.0.3)',\
+	org.apache.aries.typedevent.bus;version='[1.0.0,1.0.1)',\
 	org.apache.felix.configadmin;version='[1.9.24,1.9.25)',\
 	org.apache.felix.scr;version='[2.2.2,2.2.3)',\
 	org.eclipse.emf.common;version='[2.29.0,2.29.1)',\
@@ -48,7 +48,6 @@
 	org.eclipse.sensinact.gateway.filters.resource.selector.impl-tests;version='[0.0.2,0.0.3)',\
 	org.gecko.emf.osgi.component.minimal;version='[6.3.0,6.3.1)',\
 	org.opentest4j;version='[1.3.0,1.3.1)',\
-	org.osgi.service.cm;version='[1.6.1,1.6.2)',\
 	org.osgi.service.component;version='[1.5.0,1.5.1)',\
 	org.osgi.service.typedevent;version='[1.0.0,1.0.1)',\
 	org.osgi.test.common;version='[1.3.0,1.3.1)',\

--- a/northbound/query-handler/integration-test.bndrun
+++ b/northbound/query-handler/integration-test.bndrun
@@ -28,7 +28,7 @@
 	junit-platform-launcher;version='[1.10.1,1.10.2)',\
 	org.apache.aries.component-dsl.component-dsl;version='[1.2.2,1.2.3)',\
 	org.apache.aries.spifly.dynamic.framework.extension;version='[1.3.7,1.3.8)',\
-	org.apache.aries.typedevent.bus;version='[0.0.2,0.0.3)',\
+	org.apache.aries.typedevent.bus;version='[1.0.0,1.0.1)',\
 	org.apache.felix.configadmin;version='[1.9.24,1.9.25)',\
 	org.apache.felix.scr;version='[2.2.2,2.2.3)',\
 	org.eclipse.emf.common;version='[2.29.0,2.29.1)',\
@@ -51,7 +51,6 @@
 	org.eclipse.sensinact.gateway.northbound.session.session-impl;version='[0.0.2,0.0.3)',\
 	org.gecko.emf.osgi.component.minimal;version='[6.3.0,6.3.1)',\
 	org.opentest4j;version='[1.3.0,1.3.1)',\
-	org.osgi.service.cm;version='[1.6.1,1.6.2)',\
 	org.osgi.service.component;version='[1.5.0,1.5.1)',\
 	org.osgi.service.typedevent;version='[1.0.0,1.0.1)',\
 	org.osgi.test.common;version='[1.3.0,1.3.1)',\

--- a/northbound/rest/integration-test.bndrun
+++ b/northbound/rest/integration-test.bndrun
@@ -48,7 +48,7 @@
 	org.antlr.antlr4-runtime;version='[4.12.0,4.12.1)',\
 	org.apache.aries.component-dsl.component-dsl;version='[1.2.2,1.2.3)',\
 	org.apache.aries.spifly.dynamic.framework.extension;version='[1.3.7,1.3.8)',\
-	org.apache.aries.typedevent.bus;version='[0.0.2,0.0.3)',\
+	org.apache.aries.typedevent.bus;version='[1.0.0,1.0.1)',\
 	org.apache.felix.cm.json;version='[2.0.0,2.0.1)',\
 	org.apache.felix.configadmin;version='[1.9.24,1.9.25)',\
 	org.apache.felix.configurator;version='[1.0.18,1.0.19)',\
@@ -58,7 +58,8 @@
 	org.eclipse.emf.common;version='[2.29.0,2.29.1)',\
 	org.eclipse.emf.ecore;version='[2.35.0,2.35.1)',\
 	org.eclipse.emf.ecore.xmi;version='[2.36.0,2.36.1)',\
-	org.eclipse.jetty.http;version='[11.0.13,11.0.14)',\
+	org.eclipse.jetty.io;version='[11.0.13,11.0.14)',\
+	org.eclipse.jetty.security;version='[11.0.13,11.0.14)',\
 	org.eclipse.jetty.server;version='[11.0.13,11.0.14)',\
 	org.eclipse.jetty.util;version='[11.0.13,11.0.14)',\
 	org.eclipse.osgitech.rest;version='[1.2.2,1.2.3)',\
@@ -98,7 +99,6 @@
 	org.glassfish.jersey.media.jersey-media-sse;version='[3.1.3,3.1.4)',\
 	org.objectweb.asm;version='[9.6.0,9.6.1)',\
 	org.opentest4j;version='[1.3.0,1.3.1)',\
-	org.osgi.service.cm;version='[1.6.1,1.6.2)',\
 	org.osgi.service.component;version='[1.5.0,1.5.1)',\
 	org.osgi.service.jakartars;version='[2.0.0,2.0.1)',\
 	org.osgi.service.typedevent;version='[1.0.0,1.0.1)',\

--- a/northbound/security/openid-connect/integration-test.bndrun
+++ b/northbound/security/openid-connect/integration-test.bndrun
@@ -48,7 +48,6 @@
 	org.mockito.mockito-core;version='[5.10.0,5.10.1)',\
 	org.objenesis;version='[3.3.0,3.3.1)',\
 	org.opentest4j;version='[1.3.0,1.3.1)',\
-	org.osgi.service.cm;version='[1.6.1,1.6.2)',\
 	org.osgi.service.component;version='[1.5.0,1.5.1)',\
 	org.osgi.test.common;version='[1.3.0,1.3.1)',\
 	org.osgi.test.junit5;version='[1.3.0,1.3.1)',\

--- a/northbound/sensorthings/mqtt/integration-test.bndrun
+++ b/northbound/sensorthings/mqtt/integration-test.bndrun
@@ -43,7 +43,7 @@
 	junit-platform-launcher;version='[1.10.1,1.10.2)',\
 	org.apache.aries.component-dsl.component-dsl;version='[1.2.2,1.2.3)',\
 	org.apache.aries.spifly.dynamic.framework.extension;version='[1.3.7,1.3.8)',\
-	org.apache.aries.typedevent.bus;version='[0.0.2,0.0.3)',\
+	org.apache.aries.typedevent.bus;version='[1.0.0,1.0.1)',\
 	org.apache.felix.configadmin;version='[1.9.24,1.9.25)',\
 	org.apache.felix.scr;version='[2.2.2,2.2.3)',\
 	org.eclipse.emf.common;version='[2.29.0,2.29.1)',\
@@ -62,7 +62,6 @@
 	org.eclipse.sensinact.gateway.northbound.sensorthings.mqtt-tests;version='[0.0.2,0.0.3)',\
 	org.gecko.emf.osgi.component.minimal;version='[6.3.0,6.3.1)',\
 	org.opentest4j;version='[1.3.0,1.3.1)',\
-	org.osgi.service.cm;version='[1.6.1,1.6.2)',\
 	org.osgi.service.component;version='[1.5.0,1.5.1)',\
 	org.osgi.service.typedevent;version='[1.0.0,1.0.1)',\
 	org.osgi.test.common;version='[1.3.0,1.3.1)',\

--- a/northbound/sensorthings/rest.gateway/integration-test.bndrun
+++ b/northbound/sensorthings/rest.gateway/integration-test.bndrun
@@ -49,7 +49,7 @@
 	org.antlr.antlr4-runtime;version='[4.12.0,4.12.1)',\
 	org.apache.aries.component-dsl.component-dsl;version='[1.2.2,1.2.3)',\
 	org.apache.aries.spifly.dynamic.framework.extension;version='[1.3.7,1.3.8)',\
-	org.apache.aries.typedevent.bus;version='[0.0.2,0.0.3)',\
+	org.apache.aries.typedevent.bus;version='[1.0.0,1.0.1)',\
 	org.apache.commons.commons-compress;version='[1.24.0,1.24.1)',\
 	org.apache.felix.cm.json;version='[2.0.0,2.0.1)',\
 	org.apache.felix.configadmin;version='[1.9.24,1.9.25)',\
@@ -61,7 +61,8 @@
 	org.eclipse.emf.common;version='[2.29.0,2.29.1)',\
 	org.eclipse.emf.ecore;version='[2.35.0,2.35.1)',\
 	org.eclipse.emf.ecore.xmi;version='[2.36.0,2.36.1)',\
-	org.eclipse.jetty.http;version='[11.0.13,11.0.14)',\
+	org.eclipse.jetty.io;version='[11.0.13,11.0.14)',\
+	org.eclipse.jetty.security;version='[11.0.13,11.0.14)',\
 	org.eclipse.jetty.server;version='[11.0.13,11.0.14)',\
 	org.eclipse.jetty.util;version='[11.0.13,11.0.14)',\
 	org.eclipse.osgitech.rest;version='[1.2.2,1.2.3)',\
@@ -105,7 +106,6 @@
 	org.locationtech.spatial4j;version='[0.8.0,0.8.1)',\
 	org.objectweb.asm;version='[9.6.0,9.6.1)',\
 	org.opentest4j;version='[1.3.0,1.3.1)',\
-	org.osgi.service.cm;version='[1.6.1,1.6.2)',\
 	org.osgi.service.component;version='[1.5.0,1.5.1)',\
 	org.osgi.service.jakartars;version='[2.0.0,2.0.1)',\
 	org.osgi.service.typedevent;version='[1.0.0,1.0.1)',\

--- a/northbound/session/session-impl/integration-test.bndrun
+++ b/northbound/session/session-impl/integration-test.bndrun
@@ -32,7 +32,7 @@
 	junit-platform-launcher;version='[1.10.1,1.10.2)',\
 	org.apache.aries.component-dsl.component-dsl;version='[1.2.2,1.2.3)',\
 	org.apache.aries.spifly.dynamic.framework.extension;version='[1.3.7,1.3.8)',\
-	org.apache.aries.typedevent.bus;version='[0.0.2,0.0.3)',\
+	org.apache.aries.typedevent.bus;version='[1.0.0,1.0.1)',\
 	org.apache.felix.configadmin;version='[1.9.24,1.9.25)',\
 	org.apache.felix.scr;version='[2.2.2,2.2.3)',\
 	org.eclipse.emf.common;version='[2.29.0,2.29.1)',\
@@ -51,7 +51,6 @@
 	org.eclipse.sensinact.gateway.northbound.session.session-impl-tests;version='[0.0.2,0.0.3)',\
 	org.gecko.emf.osgi.component.minimal;version='[6.3.0,6.3.1)',\
 	org.opentest4j;version='[1.3.0,1.3.1)',\
-	org.osgi.service.cm;version='[1.6.1,1.6.2)',\
 	org.osgi.service.component;version='[1.5.0,1.5.1)',\
 	org.osgi.service.typedevent;version='[1.0.0,1.0.1)',\
 	org.osgi.test.common;version='[1.3.0,1.3.1)',\

--- a/northbound/websocket/integration-test.bndrun
+++ b/northbound/websocket/integration-test.bndrun
@@ -40,7 +40,7 @@
 	org.antlr.antlr4-runtime;version='[4.12.0,4.12.1)',\
 	org.apache.aries.component-dsl.component-dsl;version='[1.2.2,1.2.3)',\
 	org.apache.aries.spifly.dynamic.framework.extension;version='[1.3.7,1.3.8)',\
-	org.apache.aries.typedevent.bus;version='[0.0.2,0.0.3)',\
+	org.apache.aries.typedevent.bus;version='[1.0.0,1.0.1)',\
 	org.apache.felix.cm.json;version='[2.0.0,2.0.1)',\
 	org.apache.felix.configadmin;version='[1.9.24,1.9.25)',\
 	org.apache.felix.configurator;version='[1.0.18,1.0.19)',\
@@ -52,13 +52,11 @@
 	org.eclipse.emf.ecore.xmi;version='[2.36.0,2.36.1)',\
 	org.eclipse.jetty.alpn.client;version='[11.0.13,11.0.14)',\
 	org.eclipse.jetty.client;version='[11.0.13,11.0.14)',\
-	org.eclipse.jetty.http;version='[11.0.13,11.0.14)',\
+	org.eclipse.jetty.io;version='[11.0.13,11.0.14)',\
 	org.eclipse.jetty.jndi;version='[11.0.13,11.0.14)',\
 	org.eclipse.jetty.plus;version='[11.0.13,11.0.14)',\
 	org.eclipse.jetty.security;version='[11.0.13,11.0.14)',\
-	org.eclipse.jetty.server;version='[11.0.13,11.0.14)',\
 	org.eclipse.jetty.servlet;version='[11.0.13,11.0.14)',\
-	org.eclipse.jetty.util;version='[11.0.13,11.0.14)',\
 	org.eclipse.jetty.webapp;version='[11.0.13,11.0.14)',\
 	org.eclipse.jetty.websocket.api;version='[11.0.13,11.0.14)',\
 	org.eclipse.jetty.websocket.client;version='[11.0.13,11.0.14)',\
@@ -90,7 +88,6 @@
 	org.gecko.emf.osgi.component.minimal;version='[6.3.0,6.3.1)',\
 	org.objectweb.asm;version='[9.6.0,9.6.1)',\
 	org.opentest4j;version='[1.3.0,1.3.1)',\
-	org.osgi.service.cm;version='[1.6.1,1.6.2)',\
 	org.osgi.service.component;version='[1.5.0,1.5.1)',\
 	org.osgi.service.typedevent;version='[1.0.0,1.0.1)',\
 	org.osgi.test.common;version='[1.3.0,1.3.1)',\

--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,7 @@
     <felix.feature.version>1.0.2</felix.feature.version>
     <johnzon.version>2.0.0</johnzon.version>
     <aries.component-dsl.version>1.2.2</aries.component-dsl.version>
-    <aries.typedevent.version>0.0.2</aries.typedevent.version>
+    <aries.typedevent.version>1.0.0</aries.typedevent.version>
     <aries.spifly.version>1.3.7</aries.spifly.version>
     <felix.servlet.version>2.1.0</felix.servlet.version>
     <antlr.version>4.12.0</antlr.version>

--- a/southbound/history/timescale-provider/integration-test.bndrun
+++ b/southbound/history/timescale-provider/integration-test.bndrun
@@ -30,7 +30,7 @@
 	junit-platform-launcher;version='[1.10.1,1.10.2)',\
 	org.apache.aries.component-dsl.component-dsl;version='[1.2.2,1.2.3)',\
 	org.apache.aries.spifly.dynamic.framework.extension;version='[1.3.7,1.3.8)',\
-	org.apache.aries.typedevent.bus;version='[0.0.2,0.0.3)',\
+	org.apache.aries.typedevent.bus;version='[1.0.0,1.0.1)',\
 	org.apache.commons.commons-compress;version='[1.24.0,1.24.1)',\
 	org.apache.felix.configadmin;version='[1.9.24,1.9.25)',\
 	org.apache.felix.scr;version='[2.2.2,2.2.3)',\

--- a/southbound/http/http-callback-whiteboard/integration-test.bndrun
+++ b/southbound/http/http-callback-whiteboard/integration-test.bndrun
@@ -20,7 +20,6 @@
 -runbundles: \
 	ch.qos.logback.classic;version='[1.4.14,1.4.15)',\
 	ch.qos.logback.core;version='[1.4.14,1.4.15)',\
-	jakarta.servlet-api;version='[5.0.0,5.0.1)',\
 	junit-jupiter-api;version='[5.10.1,5.10.2)',\
 	junit-jupiter-engine;version='[5.10.1,5.10.2)',\
 	junit-jupiter-params;version='[5.10.1,5.10.2)',\
@@ -41,9 +40,7 @@
 	org.mockito.mockito-core;version='[5.10.0,5.10.1)',\
 	org.objenesis;version='[3.3.0,3.3.1)',\
 	org.opentest4j;version='[1.3.0,1.3.1)',\
-	org.osgi.service.cm;version='[1.6.1,1.6.2)',\
 	org.osgi.service.component;version='[1.5.0,1.5.1)',\
-	org.osgi.service.servlet;version='[2.0.0,2.0.1)',\
 	org.osgi.test.common;version='[1.3.0,1.3.1)',\
 	org.osgi.test.junit5;version='[1.3.0,1.3.1)',\
 	org.osgi.test.junit5.cm;version='[1.3.0,1.3.1)',\

--- a/southbound/http/http-device-factory/integration-test.bndrun
+++ b/southbound/http/http-device-factory/integration-test.bndrun
@@ -34,7 +34,7 @@
 	junit-platform-launcher;version='[1.10.1,1.10.2)',\
 	org.apache.aries.component-dsl.component-dsl;version='[1.2.2,1.2.3)',\
 	org.apache.aries.spifly.dynamic.framework.extension;version='[1.3.7,1.3.8)',\
-	org.apache.aries.typedevent.bus;version='[0.0.2,0.0.3)',\
+	org.apache.aries.typedevent.bus;version='[1.0.0,1.0.1)',\
 	org.apache.commons.commons-csv;version='[1.9.0,1.9.1)',\
 	org.apache.felix.configadmin;version='[1.9.24,1.9.25)',\
 	org.apache.felix.scr;version='[2.2.2,2.2.3)',\

--- a/southbound/mqtt/mqtt-device-factory/integration-test.bndrun
+++ b/southbound/mqtt/mqtt-device-factory/integration-test.bndrun
@@ -44,7 +44,7 @@
 	junit-platform-launcher;version='[1.10.1,1.10.2)',\
 	org.apache.aries.component-dsl.component-dsl;version='[1.2.2,1.2.3)',\
 	org.apache.aries.spifly.dynamic.framework.extension;version='[1.3.7,1.3.8)',\
-	org.apache.aries.typedevent.bus;version='[0.0.2,0.0.3)',\
+	org.apache.aries.typedevent.bus;version='[1.0.0,1.0.1)',\
 	org.apache.commons.commons-codec;version='[1.15.0,1.15.1)',\
 	org.apache.commons.commons-csv;version='[1.9.0,1.9.1)',\
 	org.apache.felix.configadmin;version='[1.9.24,1.9.25)',\

--- a/southbound/rules/easy-rules/config/integration-test.bndrun
+++ b/southbound/rules/easy-rules/config/integration-test.bndrun
@@ -33,7 +33,7 @@
 	net.bytebuddy.byte-buddy-agent;version='[1.14.11,1.14.12)',\
 	org.apache.aries.component-dsl.component-dsl;version='[1.2.2,1.2.3)',\
 	org.apache.aries.spifly.dynamic.framework.extension;version='[1.3.7,1.3.8)',\
-	org.apache.aries.typedevent.bus;version='[0.0.2,0.0.3)',\
+	org.apache.aries.typedevent.bus;version='[1.0.0,1.0.1)',\
 	org.apache.commons.commons-jexl3;version='[3.3.0,3.3.1)',\
 	org.apache.commons.logging;version='[1.2.0,1.2.1)',\
 	org.apache.felix.configadmin;version='[1.9.24,1.9.25)',\

--- a/southbound/rules/easy-rules/osgi/integration-test.bndrun
+++ b/southbound/rules/easy-rules/osgi/integration-test.bndrun
@@ -34,7 +34,7 @@
 	net.bytebuddy.byte-buddy-agent;version='[1.14.11,1.14.12)',\
 	org.apache.aries.component-dsl.component-dsl;version='[1.2.2,1.2.3)',\
 	org.apache.aries.spifly.dynamic.framework.extension;version='[1.3.7,1.3.8)',\
-	org.apache.aries.typedevent.bus;version='[0.0.2,0.0.3)',\
+	org.apache.aries.typedevent.bus;version='[1.0.0,1.0.1)',\
 	org.apache.felix.configadmin;version='[1.9.24,1.9.25)',\
 	org.apache.felix.scr;version='[2.2.2,2.2.3)',\
 	org.eclipse.emf.common;version='[2.29.0,2.29.1)',\

--- a/southbound/rules/rules.impl/integration-test.bndrun
+++ b/southbound/rules/rules.impl/integration-test.bndrun
@@ -33,7 +33,7 @@
 	net.bytebuddy.byte-buddy-agent;version='[1.14.11,1.14.12)',\
 	org.apache.aries.component-dsl.component-dsl;version='[1.2.2,1.2.3)',\
 	org.apache.aries.spifly.dynamic.framework.extension;version='[1.3.7,1.3.8)',\
-	org.apache.aries.typedevent.bus;version='[0.0.2,0.0.3)',\
+	org.apache.aries.typedevent.bus;version='[1.0.0,1.0.1)',\
 	org.apache.felix.configadmin;version='[1.9.24,1.9.25)',\
 	org.apache.felix.scr;version='[2.2.2,2.2.3)',\
 	org.eclipse.emf.common;version='[2.29.0,2.29.1)',\

--- a/southbound/virtual/virtual-temperature-sensor/integration-test.bndrun
+++ b/southbound/virtual/virtual-temperature-sensor/integration-test.bndrun
@@ -28,7 +28,7 @@
 	junit-platform-launcher;version='[1.10.1,1.10.2)',\
 	org.apache.aries.component-dsl.component-dsl;version='[1.2.2,1.2.3)',\
 	org.apache.aries.spifly.dynamic.framework.extension;version='[1.3.7,1.3.8)',\
-	org.apache.aries.typedevent.bus;version='[0.0.2,0.0.3)',\
+	org.apache.aries.typedevent.bus;version='[1.0.0,1.0.1)',\
 	org.apache.felix.configadmin;version='[1.9.24,1.9.25)',\
 	org.apache.felix.scr;version='[2.2.2,2.2.3)',\
 	org.eclipse.emf.common;version='[2.29.0,2.29.1)',\

--- a/southbound/wot/core/integration-test.bndrun
+++ b/southbound/wot/core/integration-test.bndrun
@@ -34,7 +34,7 @@
 	net.bytebuddy.byte-buddy-agent;version='[1.14.11,1.14.12)',\
 	org.apache.aries.component-dsl.component-dsl;version='[1.2.2,1.2.3)',\
 	org.apache.aries.spifly.dynamic.framework.extension;version='[1.3.7,1.3.8)',\
-	org.apache.aries.typedevent.bus;version='[0.0.2,0.0.3)',\
+	org.apache.aries.typedevent.bus;version='[1.0.0,1.0.1)',\
 	org.apache.felix.configadmin;version='[1.9.24,1.9.25)',\
 	org.apache.felix.scr;version='[2.2.2,2.2.3)',\
 	org.eclipse.emf.common;version='[2.29.0,2.29.1)',\

--- a/southbound/wot/http/integration-test.bndrun
+++ b/southbound/wot/http/integration-test.bndrun
@@ -32,7 +32,7 @@
 	junit-platform-launcher;version='[1.10.1,1.10.2)',\
 	org.apache.aries.component-dsl.component-dsl;version='[1.2.2,1.2.3)',\
 	org.apache.aries.spifly.dynamic.framework.extension;version='[1.3.7,1.3.8)',\
-	org.apache.aries.typedevent.bus;version='[0.0.2,0.0.3)',\
+	org.apache.aries.typedevent.bus;version='[1.0.0,1.0.1)',\
 	org.apache.felix.configadmin;version='[1.9.24,1.9.25)',\
 	org.apache.felix.scr;version='[2.2.2,2.2.3)',\
 	org.eclipse.emf.common;version='[2.29.0,2.29.1)',\


### PR DESCRIPTION
The Aries Typed Events 1.0.0 release contains some useful bug fixes and also support for:

* Record types as events
* Single level wildcards (enable in config)