### PR TITLE
Support pushed updates using Java Records

### DIFF
--- a/core/annotation/src/main/java/org/eclipse/sensinact/core/annotation/dto/Data.java
+++ b/core/annotation/src/main/java/org/eclipse/sensinact/core/annotation/dto/Data.java
@@ -30,7 +30,7 @@ import java.lang.annotation.Target;
  *
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.FIELD })
+@Target({ ElementType.FIELD, ElementType.RECORD_COMPONENT })
 public @interface Data {
     /**
      * The type of the resource data. If not set then the type of the DTO field is

--- a/core/annotation/src/main/java/org/eclipse/sensinact/core/annotation/dto/Metadata.java
+++ b/core/annotation/src/main/java/org/eclipse/sensinact/core/annotation/dto/Metadata.java
@@ -31,7 +31,7 @@ import java.lang.annotation.Target;
  *
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.FIELD })
+@Target({ ElementType.FIELD, ElementType.RECORD_COMPONENT })
 public @interface Metadata {
     /**
      * The name of the metadata field, if not set then the dto field name is used

--- a/core/annotation/src/main/java/org/eclipse/sensinact/core/annotation/dto/Model.java
+++ b/core/annotation/src/main/java/org/eclipse/sensinact/core/annotation/dto/Model.java
@@ -45,7 +45,7 @@ import java.lang.annotation.Target;
  *
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.TYPE, ElementType.FIELD })
+@Target({ ElementType.TYPE, ElementType.FIELD, ElementType.RECORD_COMPONENT })
 public @interface Model {
     /**
      * The name of the provider

--- a/core/annotation/src/main/java/org/eclipse/sensinact/core/annotation/dto/ModelPackageUri.java
+++ b/core/annotation/src/main/java/org/eclipse/sensinact/core/annotation/dto/ModelPackageUri.java
@@ -46,7 +46,7 @@ import java.lang.annotation.Target;
  *
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.TYPE, ElementType.FIELD })
+@Target({ ElementType.TYPE, ElementType.FIELD, ElementType.RECORD_COMPONENT })
 public @interface ModelPackageUri {
     /**
      * The name of the provider

--- a/core/annotation/src/main/java/org/eclipse/sensinact/core/annotation/dto/Provider.java
+++ b/core/annotation/src/main/java/org/eclipse/sensinact/core/annotation/dto/Provider.java
@@ -46,7 +46,7 @@ import java.lang.annotation.Target;
  *
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.TYPE, ElementType.FIELD })
+@Target({ ElementType.TYPE, ElementType.FIELD, ElementType.RECORD_COMPONENT })
 @Inherited
 public @interface Provider {
     /**

--- a/core/annotation/src/main/java/org/eclipse/sensinact/core/annotation/dto/Resource.java
+++ b/core/annotation/src/main/java/org/eclipse/sensinact/core/annotation/dto/Resource.java
@@ -47,7 +47,7 @@ import java.lang.annotation.Target;
  *
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.TYPE, ElementType.FIELD })
+@Target({ ElementType.TYPE, ElementType.FIELD, ElementType.RECORD_COMPONENT })
 @Inherited
 public @interface Resource {
     String value() default AnnotationConstants.NOT_SET;

--- a/core/annotation/src/main/java/org/eclipse/sensinact/core/annotation/dto/Service.java
+++ b/core/annotation/src/main/java/org/eclipse/sensinact/core/annotation/dto/Service.java
@@ -45,7 +45,7 @@ import java.lang.annotation.Target;
  *
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ ElementType.TYPE, ElementType.FIELD })
+@Target({ ElementType.TYPE, ElementType.FIELD, ElementType.RECORD_COMPONENT })
 @Inherited
 public @interface Service {
     /**

--- a/core/annotation/src/main/java/org/eclipse/sensinact/core/annotation/dto/Timestamp.java
+++ b/core/annotation/src/main/java/org/eclipse/sensinact/core/annotation/dto/Timestamp.java
@@ -30,7 +30,7 @@ import java.time.temporal.Temporal;
  * </ul>
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.FIELD)
+@Target({ElementType.FIELD, ElementType.RECORD_COMPONENT})
 public @interface Timestamp {
     /**
      * The unit of time this represents since the epoch, either


### PR DESCRIPTION
This commit enhances the AnnotationMapping utility to scan Java Records as well as DTO types. This offers consistent handling whichever mechanism the user chooses to use.

Fixes #515