### PR TITLE
Update to testcontainers 1.21 and move dependency to parent

### DIFF
--- a/distribution/features/timescale-history-provider-feature/pom.xml
+++ b/distribution/features/timescale-history-provider-feature/pom.xml
@@ -56,7 +56,7 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>postgresql</artifactId>
-      <version>1.19.1</version>
+      <version>${testcontainers.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/northbound/sensorthings/rest.gateway/integration-test.bndrun
+++ b/northbound/sensorthings/rest.gateway/integration-test.bndrun
@@ -30,7 +30,7 @@
 	com.fasterxml.jackson.datatype.jackson-datatype-jsr310;version='[2.16.1,2.16.2)',\
 	com.fasterxml.jackson.jakarta.rs.jackson-jakarta-rs-base;version='[2.16.1,2.16.2)',\
 	com.fasterxml.jackson.jakarta.rs.jackson-jakarta-rs-json-provider;version='[2.16.1,2.16.2)',\
-	com.sun.jna;version='[5.12.1,5.12.2)',\
+	com.sun.jna;version='[5.13.0,5.13.1)',\
 	io.dropwizard.metrics.core;version='[4.2.19,4.2.20)',\
 	jakarta.activation-api;version='[2.1.0,2.1.1)',\
 	jakarta.annotation-api;version='[2.1.1,2.1.2)',\

--- a/northbound/sensorthings/rest.gateway/pom.xml
+++ b/northbound/sensorthings/rest.gateway/pom.xml
@@ -184,7 +184,7 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>postgresql</artifactId>
-      <version>1.19.1</version>
+      <version>${testcontainers.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/northbound/sensorthings/rest.gateway/tests.bnd
+++ b/northbound/sensorthings/rest.gateway/tests.bnd
@@ -1,11 +1,11 @@
 -includeresource: \
-    @postgresql-1.19.1.jar, \
-    @jdbc-1.19.1.jar, \
-    @database-commons-1.19.1.jar, \
-    @testcontainers-1.19.1.jar, \
-    @docker-java-api-3.3.3.jar, \
-    @docker-java-transport-zerodep-3.3.3.jar, \
-    @docker-java-transport-3.3.3.jar,\
+    @postgresql-1.21.0.jar, \
+    @jdbc-1.21.0.jar, \
+    @database-commons-1.21.0.jar, \
+    @testcontainers-1.21.0.jar, \
+    @docker-java-api-3.4.2.jar, \
+    @docker-java-transport-zerodep-3.4.2.jar, \
+    @docker-java-transport-3.4.2.jar,\
     @duct-tape-1.0.8.jar
 
 Import-Package: \
@@ -18,4 +18,5 @@ Import-Package: \
     !javax.annotation.*, \
     !org.conscrypt, \
     !org.testcontainers.r2dbc.*, \
+    !sun.nio.ch, \
     *

--- a/pom.xml
+++ b/pom.xml
@@ -152,6 +152,7 @@
     <junit.version>5.10.1</junit.version>
     <mockito.version>5.10.0</mockito.version>
     <osgi.test.version>1.3.0</osgi.test.version>
+    <testcontainers.version>1.21.0</testcontainers.version>
 
     <!-- plugin dependency versions -->
     <bnd.version>7.0.0</bnd.version>
@@ -473,6 +474,18 @@
         <groupId>org.geckoprojects.emf</groupId>
         <artifactId>org.gecko.emf.osgi.codegen</artifactId>
         <version>${gecko.emf.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>testcontainers</artifactId>
+        <version>${testcontainers.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>junit-jupiter</artifactId>
+        <version>${testcontainers.version}</version>
+        <scope>test</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/southbound/history/timescale-provider/integration-test.bndrun
+++ b/southbound/history/timescale-provider/integration-test.bndrun
@@ -20,7 +20,7 @@
 	com.fasterxml.jackson.core.jackson-annotations;version='[2.16.1,2.16.2)',\
 	com.fasterxml.jackson.core.jackson-core;version='[2.16.1,2.16.2)',\
 	com.fasterxml.jackson.core.jackson-databind;version='[2.16.1,2.16.2)',\
-	com.sun.jna;version='[5.12.1,5.12.2)',\
+	com.sun.jna;version='[5.13.0,5.13.1)',\
 	io.dropwizard.metrics.core;version='[4.2.19,4.2.20)',\
 	junit-jupiter-api;version='[5.10.1,5.10.2)',\
 	junit-jupiter-engine;version='[5.10.1,5.10.2)',\

--- a/southbound/history/timescale-provider/pom.xml
+++ b/southbound/history/timescale-provider/pom.xml
@@ -105,7 +105,7 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>postgresql</artifactId>
-      <version>1.19.1</version>
+      <version>${testcontainers.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/southbound/history/timescale-provider/tests.bnd
+++ b/southbound/history/timescale-provider/tests.bnd
@@ -1,11 +1,11 @@
 -includeresource: \
-    @postgresql-1.19.1.jar, \
-    @jdbc-1.19.1.jar, \
-    @database-commons-1.19.1.jar, \
-    @testcontainers-1.19.1.jar, \
-    @docker-java-api-3.3.3.jar, \
-    @docker-java-transport-zerodep-3.3.3.jar, \
-    @docker-java-transport-3.3.3.jar,\
+    @postgresql-1.21.0.jar, \
+    @jdbc-1.21.0.jar, \
+    @database-commons-1.21.0.jar, \
+    @testcontainers-1.21.0.jar, \
+    @docker-java-api-3.4.2.jar, \
+    @docker-java-transport-zerodep-3.4.2.jar, \
+    @docker-java-transport-3.4.2.jar,\
     @duct-tape-1.0.8.jar
 
 Import-Package: \
@@ -18,6 +18,7 @@ Import-Package: \
     !javax.annotation.*, \
     !org.conscrypt, \
     !org.testcontainers.r2dbc.*, \
+    !sun.nio.ch, \
     *
 # Remove warnings about annotation dependencies from repackaged code
 -fixupmessages: \


### PR DESCRIPTION
This commit updates to the latest release of testcontainers, and centralises the dependency in parent. This is necessary as the dependency is used in multiple parts of the gateway build, such as northbound, southbound and distribution