### PR TITLE
Sensorthings specification alignments

### DIFF
--- a/northbound/sensorthings/dto/src/main/java/org/eclipse/sensinact/sensorthings/sensing/dto/Datastream.java
+++ b/northbound/sensorthings/dto/src/main/java/org/eclipse/sensinact/sensorthings/sensing/dto/Datastream.java
@@ -14,10 +14,9 @@ package org.eclipse.sensinact.sensorthings.sensing.dto;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
-import java.time.Instant;
 import java.util.Map;
 
-import org.eclipse.sensinact.gateway.geojson.Polygon;
+import org.eclipse.sensinact.gateway.geojson.Geometry;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -30,15 +29,15 @@ public class Datastream extends NameDescription {
     public UnitOfMeasurement unitOfMeasurement;
 
     @JsonInclude(NON_NULL)
-    public Polygon observedArea;
+    public Geometry observedArea;
 
     @JsonInclude(NON_NULL)
     @JsonFormat(shape = JsonFormat.Shape.STRING)
-    public Instant phenomenonTime;
+    public TimeInterval phenomenonTime;
 
     @JsonInclude(NON_NULL)
     @JsonFormat(shape = JsonFormat.Shape.STRING)
-    public Instant resultTime;
+    public TimeInterval resultTime;
 
     @JsonInclude(NON_NULL)
     public Map<String, Object> properties;

--- a/northbound/sensorthings/dto/src/main/java/org/eclipse/sensinact/sensorthings/sensing/dto/Observation.java
+++ b/northbound/sensorthings/dto/src/main/java/org/eclipse/sensinact/sensorthings/sensing/dto/Observation.java
@@ -36,7 +36,7 @@ public class Observation extends Id {
 
     @JsonInclude(NON_NULL)
     @JsonFormat(shape = JsonFormat.Shape.STRING)
-    public Instant validTime;
+    public TimeInterval validTime;
 
     @JsonInclude(NON_NULL)
     public Map<String, Object> parameters;

--- a/northbound/sensorthings/dto/src/main/java/org/eclipse/sensinact/sensorthings/sensing/dto/TimeInterval.java
+++ b/northbound/sensorthings/dto/src/main/java/org/eclipse/sensinact/sensorthings/sensing/dto/TimeInterval.java
@@ -1,0 +1,31 @@
+/*********************************************************************
+* Copyright (c) 2025 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   Kentyou - initial implementation
+**********************************************************************/
+package org.eclipse.sensinact.sensorthings.sensing.dto;
+
+import java.time.Instant;
+
+import org.eclipse.sensinact.sensorthings.sensing.dto.jackson.TimeIntervalDeserializer;
+import org.eclipse.sensinact.sensorthings.sensing.dto.jackson.TimeIntervalSerializer;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+@JsonDeserialize(using = TimeIntervalDeserializer.class)
+@JsonSerialize(using = TimeIntervalSerializer.class)
+public class TimeInterval {
+
+    public Instant start;
+
+    public Instant end;
+
+}

--- a/northbound/sensorthings/dto/src/main/java/org/eclipse/sensinact/sensorthings/sensing/dto/jackson/TimeIntervalDeserializer.java
+++ b/northbound/sensorthings/dto/src/main/java/org/eclipse/sensinact/sensorthings/sensing/dto/jackson/TimeIntervalDeserializer.java
@@ -1,0 +1,85 @@
+/*********************************************************************
+* Copyright (c) 2025 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   Kentyou - initial implementation
+**********************************************************************/
+package org.eclipse.sensinact.sensorthings.sensing.dto.jackson;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+
+import org.eclipse.sensinact.sensorthings.sensing.dto.TimeInterval;
+
+import com.fasterxml.jackson.core.JacksonException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
+
+public class TimeIntervalDeserializer extends JsonDeserializer<TimeInterval> {
+
+    @Override
+    public TimeInterval deserialize(JsonParser p, DeserializationContext ctxt)
+            throws IOException, JacksonException {
+        if(p.currentToken() != JsonToken.VALUE_STRING) {
+            throw MismatchedInputException.from(p, TimeInterval.class,
+                    "Must be serialized as an ISO 8601 Time Interval String, not " + p.currentToken());
+        }
+        String value = p.getText();
+
+        int slash = value.indexOf('/');
+        if(slash < 0) {
+            failFormat(p, value);
+        }
+
+        String first = value.substring(0, slash);
+        String second = value.substring(slash + 1, value.length());
+
+        TimeInterval ti = new TimeInterval();
+        if(first.startsWith("P")) {
+            if(second.startsWith("P")) {
+                failFormat(p, value);
+            } else {
+                try {
+                    Duration d = Duration.parse(first);
+                    ti.end = Instant.parse(second);
+                    ti.start = ti.end.minus(d);
+                } catch (Exception e) {
+                    failFormat(p, value);
+                }
+            }
+        } else if(second.startsWith("P")) {
+            try {
+                Duration d = Duration.parse(second);
+                ti.start = Instant.parse(first);
+                ti.end = ti.start.plus(d);
+            } catch (Exception e) {
+                failFormat(p, value);
+            }
+        } else {
+            try {
+                ti.start = Instant.parse(first);
+                ti.end = Instant.parse(second);
+            } catch (Exception e) {
+                failFormat(p, value);
+            }
+        }
+
+        return ti;
+    }
+
+    void failFormat(JsonParser p, String value) throws InvalidFormatException {
+        throw new InvalidFormatException(p, "Must be serialized as an ISO 8601 Time Interval String",
+                value, TimeInterval.class);
+    }
+}

--- a/northbound/sensorthings/dto/src/main/java/org/eclipse/sensinact/sensorthings/sensing/dto/jackson/TimeIntervalSerializer.java
+++ b/northbound/sensorthings/dto/src/main/java/org/eclipse/sensinact/sensorthings/sensing/dto/jackson/TimeIntervalSerializer.java
@@ -1,0 +1,30 @@
+/*********************************************************************
+* Copyright (c) 2025 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   Kentyou - initial implementation
+**********************************************************************/
+package org.eclipse.sensinact.sensorthings.sensing.dto.jackson;
+
+import java.io.IOException;
+
+import org.eclipse.sensinact.sensorthings.sensing.dto.TimeInterval;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+public class TimeIntervalSerializer extends JsonSerializer<TimeInterval> {
+
+    @Override
+    public void serialize(TimeInterval value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+        gen.writeString(value.start.toString() + "/" + value.end.toString());
+    }
+
+}


### PR DESCRIPTION
This commit fixes two issues with the sensorthings DTOs

* The DataStream and Observation types used Instant to represent fields that are, in fact, time intervals. As Java has no built in type for this the commit adds TimeInterval, including a Jackson parser for the formats permitted by ISO 8601 (start and end, start and duration, duration and end)
* The Datastream observedArea has been loosened to permit any GeoJSON Geometry. This is to fit with the observed behaviour of FROST server (the reference implementation) which does not enforce that the observed area is a Polygon (unlike the specification text)