### PR TITLE
Move extra FeatureCustomMetadata from list to map

### DIFF
--- a/core/impl/src/main/java/org/eclipse/sensinact/core/model/nexus/ModelNexus.java
+++ b/core/impl/src/main/java/org/eclipse/sensinact/core/model/nexus/ModelNexus.java
@@ -35,6 +35,9 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.eclipse.emf.common.util.BasicEMap;
+import org.eclipse.emf.common.util.ECollections;
+import org.eclipse.emf.common.util.EMap;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EAttribute;
 import org.eclipse.emf.ecore.EClass;
@@ -588,17 +591,18 @@ public class ModelNexus {
         if (getterCacheMs > 0) {
             resourceMetaData.setExternalGetCacheMs(getterCacheMs);
         }
-        List<FeatureCustomMetadata> defaultFeatureMetadata = defaultMetadata == null ? List.of()
+        EMap<String, FeatureCustomMetadata> defaultFeatureMetadata = defaultMetadata == null ? ECollections.emptyEMap()
                 : toDefaultFeatureCustomMetadata(defaultMetadata);
         EMFUtil.fillMetadata(resourceMetaData, timestamp, false, resource, defaultFeatureMetadata);
         return (EAttribute) resourceMetaData.eContainer().eContainer();
     }
 
-    private List<FeatureCustomMetadata> toDefaultFeatureCustomMetadata(Map<String, Object> defaultMetadata) {
-        List<FeatureCustomMetadata> defaultFeatureMetadata = defaultMetadata.entrySet().stream()
-                .map(e -> EMFUtil.createFeatureCustomMetadata(e.getKey(), null, e.getValue()))
-                .collect(Collectors.toList());
-        return defaultFeatureMetadata;
+    private EMap<String, FeatureCustomMetadata> toDefaultFeatureCustomMetadata(Map<String, Object> defaultMetadata) {
+        HashMap<String, FeatureCustomMetadata> m = new HashMap<>();
+        for (Entry<String, Object> entry : defaultMetadata.entrySet()) {
+            m.put(entry.getKey(), EMFUtil.createFeatureCustomMetadata(null, entry.getValue()));
+        }
+        return new BasicEMap<>(m);
     }
 
     private void assertResourceNotExist(EClass service, String resource) {
@@ -632,7 +636,7 @@ public class ModelNexus {
         EClass model = EMFUtil.createEClass(modelClassName, ePackage, null, ProviderPackage.Literals.PROVIDER);
         ModelMetadata metadata = ProviderFactory.eINSTANCE.createModelMetadata();
         EMFUtil.addMetaDataAnnnotation(model, metadata);
-        EMFUtil.fillMetadata(metadata, timestamp, false, modelName, List.of());
+        EMFUtil.fillMetadata(metadata, timestamp, false, modelName, ECollections.emptyEMap());
         return model;
     }
 
@@ -641,7 +645,7 @@ public class ModelNexus {
         EClass service = EMFUtil.createEClass(NamingUtils.sanitizeName(name, false), ePackage, null,
                 ProviderPackage.Literals.SERVICE);
         EReference ref = EMFUtil.createServiceReference(model, name, service, true);
-        EMFUtil.fillMetadata(EMFUtil.getModelMetadata(ref), timestamp, false, name, List.of());
+        EMFUtil.fillMetadata(EMFUtil.getModelMetadata(ref), timestamp, false, name, ECollections.emptyEMap());
         return ref;
     }
 
@@ -681,15 +685,15 @@ public class ModelNexus {
 
         final ResourceValueMetadata metadata = getOrInitializeResourceMetadata(svc, rcFeature);
         if (metadata != null) {
-            for (FeatureCustomMetadata entry : metadata.getExtra()) {
-                if (entry.getName().equals(key)) {
-                    return new DefaultTimedValue<Object>(entry.getValue(), entry.getTimestamp());
-                }
-            }
-            // If the resource exists but has no metadata for that key then return an
-            // empty timed value indicating that the resource exists but the metadata
-            // is not set
-            return new DefaultTimedValue<Object>(null, null);
+            EMap<String, FeatureCustomMetadata> extra = metadata.getExtra();
+            FeatureCustomMetadata featureCustomMetadata = extra.get(key);
+            if (featureCustomMetadata != null)
+                return new DefaultTimedValue<>(featureCustomMetadata.getValue(), featureCustomMetadata.getTimestamp());
+            else
+                // If the resource exists but has no metadata for that key then return an
+                // empty timed value indicating that the resource exists but the metadata
+                // is not set
+                return new DefaultTimedValue<>(null, null);
         }
         return null;
     }
@@ -731,10 +735,13 @@ public class ModelNexus {
 
         Map<String, Object> oldMetadata = EMFUtil.toMetadataAttributesToMap(metadata, resource);
 
-        metadata.getExtra().stream().filter(fcm -> fcm.getName().equals(metadataKey)).findFirst().ifPresentOrElse(
-                fcm -> EMFUtil.handleFeatureCustomMetadata(fcm, metadataKey, timestamp, value),
-                () -> metadata.getExtra().add(EMFUtil.createFeatureCustomMetadata(metadataKey, timestamp, value)));
-
+        EMap<String, FeatureCustomMetadata> extra = metadata.getExtra();
+        FeatureCustomMetadata fcm = extra.get(metadataKey);
+        if(fcm == null) {
+            extra.put(metadataKey, EMFUtil.createFeatureCustomMetadata(timestamp, value));
+        } else {
+            EMFUtil.handleFeatureCustomMetadata(fcm, timestamp, value);
+        }
         Map<String, Object> newMetadata = EMFUtil.toMetadataAttributesToMap(metadata, resource);
 
         notificationAccumulator.get().metadataValueUpdate(provider.eClass().getEPackage().getNsURI(),
@@ -869,7 +876,7 @@ public class ModelNexus {
         List<EParameter> params = namedParameterTypes.stream().map(EMFUtil::createActionParameter)
                 .collect(Collectors.toList());
 
-        List<FeatureCustomMetadata> defaultFeatureMetadata = defaultMetadata == null ? List.of()
+        EMap<String, FeatureCustomMetadata>  defaultFeatureMetadata = defaultMetadata == null ? new BasicEMap<>()
                 : toDefaultFeatureCustomMetadata(defaultMetadata);
 
         EOperation action = EMFUtil.createAction(serviceEClass, name, type, params);

--- a/core/impl/src/main/java/org/eclipse/sensinact/core/model/nexus/emf/compare/EMFCompareUtil.java
+++ b/core/impl/src/main/java/org/eclipse/sensinact/core/model/nexus/emf/compare/EMFCompareUtil.java
@@ -15,13 +15,15 @@ package org.eclipse.sensinact.core.model.nexus.emf.compare;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.function.Predicate;
 
-import org.eclipse.emf.common.util.EList;
+import org.eclipse.emf.common.util.EMap;
 import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EReference;
@@ -329,39 +331,29 @@ public class EMFCompareUtil {
         return resourceMetadata;
     }
 
-    private static void updateExtraMetadata(EList<FeatureCustomMetadata> extraNew,
-            EList<FeatureCustomMetadata> extraOriginal, Instant newTimestamp) {
+    private static void updateExtraMetadata(EMap<String, FeatureCustomMetadata> extraNew,
+            EMap<String, FeatureCustomMetadata> extraOriginal, Instant newTimestamp) {
         if (extraNew.isEmpty() && extraOriginal.isEmpty()) {
             return;
         }
-        List<FeatureCustomMetadata> toRemove = new ArrayList<>(extraOriginal);
-
-        extraNew.forEach(fcm -> {
-            FeatureCustomMetadata original = removeByName(fcm.getName(), toRemove);
+        Map<String, FeatureCustomMetadata> toRemoveMap = new HashMap<>();
+        extraOriginal.forEach(e -> toRemoveMap.put(e.getKey(), e.getValue()));
+        extraNew.forEach(e -> {
+            FeatureCustomMetadata fcm = e.getValue();
+            FeatureCustomMetadata original = toRemoveMap.remove(e.getKey());
             Instant timestamp = fcm.getTimestamp() == null ? newTimestamp : fcm.getTimestamp();
             if (original == null) {
                 FeatureCustomMetadata copy = EcoreUtil.copy(fcm);
                 if (copy.getTimestamp() == null) {
                     copy.setTimestamp(newTimestamp);
                 }
-                extraOriginal.add(copy);
+                extraOriginal.put(e.getKey(), copy);
             } else if (original.getTimestamp().plusMillis(1).isBefore(timestamp)) {
                 original.setValue(fcm.getValue());
-                original.getTimestamp();
+                original.setTimestamp(timestamp);
             }
         });
-        extraOriginal.removeAll(toRemove);
-    }
-
-    private static FeatureCustomMetadata removeByName(String name, List<FeatureCustomMetadata> compareList) {
-        for (Iterator<FeatureCustomMetadata> iterator = compareList.iterator(); iterator.hasNext();) {
-            FeatureCustomMetadata featureCustomMetadata = iterator.next();
-            if (name.equals(featureCustomMetadata.getName())) {
-                iterator.remove();
-                return featureCustomMetadata;
-            }
-        }
-        return null;
+        toRemoveMap.keySet().forEach(extraOriginal::removeKey);
     }
 
     private static Instant getNewTimestampFromMetadata(EStructuralFeature resource, Service service) {
@@ -411,9 +403,18 @@ public class EMFCompareUtil {
             result = ProviderFactory.eINSTANCE.createResourceValueMetadata();
             result.setTimestamp(Instant.now());
             service.getMetadata().put(attribute, result);
-        } else if (result.getTimestamp() == null) {
+            return result;
+        }
+
+        if (result.getTimestamp() == null) {
             result.setTimestamp(Instant.now());
         }
+
+        result.getExtra().stream() //
+                .map(Entry::getValue)
+                .filter(fcm -> fcm.getTimestamp() == null) //
+                .forEach(fcm -> fcm.setTimestamp(Instant.now()));
+
         return result;
     }
 

--- a/core/impl/src/test/java/org/eclipse/sensinact/core/integration/EMFUpdateServiceTest.java
+++ b/core/impl/src/test/java/org/eclipse/sensinact/core/integration/EMFUpdateServiceTest.java
@@ -41,6 +41,7 @@ import org.eclipse.sensinact.core.twin.SensinactDigitalTwin;
 import org.eclipse.sensinact.core.twin.SensinactProvider;
 import org.eclipse.sensinact.core.twin.SensinactResource;
 import org.eclipse.sensinact.gateway.geojson.Point;
+import org.eclipse.sensinact.model.core.provider.FeatureCustomMetadata;
 import org.eclipse.sensinact.model.core.provider.ProviderFactory;
 import org.eclipse.sensinact.model.core.provider.ResourceValueMetadata;
 import org.eclipse.sensinact.model.core.testdata.DynamicTestSensor;
@@ -158,21 +159,25 @@ public class EMFUpdateServiceTest {
             EMap<ETypedElement, ResourceValueMetadata> metadata = temp.getMetadata();
             ResourceValueMetadata md = ProviderFactory.eINSTANCE.createResourceValueMetadata();
             metadata.put(TestdataPackage.eINSTANCE.getTestTemperatur_V1(), md);
+            EMap<String, FeatureCustomMetadata> extra = md.getExtra();
+            FeatureCustomMetadata fcmd = ProviderFactory.eINSTANCE.createFeatureCustomMetadata();
+            extra.put("FCMD Name", fcmd);
 
             Instant before = Instant.now();
             Promise<?> update = push.pushUpdate(sensor);
             assertNull(update.getFailure());
+            Instant after = Instant.now();
             assertEquals("14 °C", getResourceValue("TestSensor", PROVIDER, SERVICE, RESOURCE));
             Instant current = getResourceTimestamp("TestSensor", PROVIDER, SERVICE, RESOURCE);
             assertNotNull(current);
-            Instant after = Instant.now();
             assertTrue(before.isBefore(current));
             assertTrue(after.isAfter(current));
 
             temp.setV1("13 °C");
             before = Instant.now();
             update = push.pushUpdate(sensor);
-            assertNull(update.getFailure());
+            Throwable failure = update.getFailure();
+            assertNull(failure, () -> "Fails with " + failure.getMessage());
             assertEquals("13 °C", getResourceValue("TestSensor", PROVIDER, SERVICE, RESOURCE));
             current = getResourceTimestamp("TestSensor", PROVIDER, SERVICE, RESOURCE);
             assertNotNull(current);

--- a/core/impl/src/test/java/org/eclipse/sensinact/core/model/nexus/impl/SubscriptionTest.java
+++ b/core/impl/src/test/java/org/eclipse/sensinact/core/model/nexus/impl/SubscriptionTest.java
@@ -779,10 +779,9 @@ public class SubscriptionTest {
             ResourceValueMetadata newMetadata = ProviderFactory.eINSTANCE.createResourceValueMetadata();
             newMetadata.setTimestamp(Instant.now());
             FeatureCustomMetadata fcm = ProviderFactory.eINSTANCE.createFeatureCustomMetadata();
-            fcm.setName("test.meta.1");
             fcm.setValue("some Test");
             fcm.setTimestamp(Instant.now());
-            newMetadata.getExtra().add(fcm);
+            newMetadata.getExtra().put("test.meta.1", fcm);
             ((Service) saved.eGet(provider.eClass().getEStructuralFeature("testService1"))).getMetadata()
                     .put(testService1.eClass().getEStructuralFeature("foo2"), newMetadata);
 
@@ -850,21 +849,19 @@ public class SubscriptionTest {
                     .getMetadata().get(testService1.eClass().getEStructuralFeature("foo"));
 
             FeatureCustomMetadata fcm = ProviderFactory.eINSTANCE.createFeatureCustomMetadata();
-            fcm.setName("test.meta.1");
             fcm.setValue("some Test");
             fcm.setTimestamp(Instant.now());
 
-            oldMetadata.getExtra().add(fcm);
+            oldMetadata.getExtra().put("test.meta.1", fcm);
 
             fcm = ProviderFactory.eINSTANCE.createFeatureCustomMetadata();
-            fcm.setName("test.meta.2");
             fcm.setValue(2);
             fcm.setTimestamp(Instant.now());
 
             Instant mark = Instant.now();
             Thread.sleep(100);
 
-            oldMetadata.getExtra().add(fcm);
+            oldMetadata.getExtra().put("test.meta.2", fcm);
 
             Instant oldMetadataTimestampToCompare = oldMetadata.getTimestamp();
 
@@ -1001,10 +998,9 @@ public class SubscriptionTest {
 
             overwrite = ProviderFactory.eINSTANCE.createResourceValueMetadata();
             FeatureCustomMetadata fcm = ProviderFactory.eINSTANCE.createFeatureCustomMetadata();
-            fcm.setName("test");
             fcm.setValue("Something different");
             fcm.setTimestamp(Instant.now());
-            overwrite.getExtra().add(fcm);
+            overwrite.getExtra().put("test", fcm);
 
             ((Service) saved.eGet(provider.eClass().getEStructuralFeature("testService2"))).getMetadata()
                     .put(testService2.eClass().getEStructuralFeature("annotated"), overwrite);
@@ -1025,8 +1021,8 @@ public class SubscriptionTest {
             assertTrue(curMetadata.getTimestamp().isAfter(mark));
             assertNotEquals(overwrite, curMetadata);
             assertEquals(1, curMetadata.getExtra().size());
-            assertEquals("test", curMetadata.getExtra().get(0).getName());
-            assertEquals(fcm.getValue(), curMetadata.getExtra().get(0).getValue());
+            assertNotNull(curMetadata.getExtra().get("test"));
+            assertEquals(fcm.getValue(), curMetadata.getExtra().get("test").getValue());
 
             String modelName = EMFUtil.getModelName(provider.eClass());
 
@@ -1071,18 +1067,16 @@ public class SubscriptionTest {
             metadata.setTimestamp(Instant.now());
             testService1.getMetadata().put(testService1.eClass().getEStructuralFeature("foo"), metadata);
             FeatureCustomMetadata fcm = ProviderFactory.eINSTANCE.createFeatureCustomMetadata();
-            fcm.setName("test.meta.1");
             fcm.setValue("some Test");
             fcm.setTimestamp(Instant.now());
 
-            metadata.getExtra().add(fcm);
+            metadata.getExtra().put("test.meta.1", fcm);
 
             fcm = ProviderFactory.eINSTANCE.createFeatureCustomMetadata();
-            fcm.setName("test.meta.2");
             fcm.setValue(2);
             fcm.setTimestamp(Instant.now());
 
-            metadata.getExtra().add(fcm);
+            metadata.getExtra().put("test.meta.2", fcm);
 
             Provider saved = nexus.save(provider);
 

--- a/core/models/provider/src/main/resources/model/sensinact.ecore
+++ b/core/models/provider/src/main/resources/model/sensinact.ecore
@@ -45,7 +45,7 @@
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="Metadata" abstract="true">
     <eStructuralFeatures xsi:type="ecore:EReference" name="extra" upperBound="-1"
-        eType="#//FeatureCustomMetadata" containment="true"/>
+        eType="#//FeatureCustomMetadataMap" containment="true"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="timestamp" eType="#//EInstant"/>
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EClass" name="FeatureMetadata" instanceClassName="java.util.Map$Entry">
@@ -55,7 +55,6 @@
   </eClassifiers>
   <eClassifiers xsi:type="ecore:EDataType" name="EInstant" instanceClassName="java.time.Instant"/>
   <eClassifiers xsi:type="ecore:EClass" name="FeatureCustomMetadata">
-    <eStructuralFeatures xsi:type="ecore:EAttribute" name="name" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="timestamp" eType="#//EInstant"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="value" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EJavaObject"/>
   </eClassifiers>
@@ -125,4 +124,9 @@
   <eClassifiers xsi:type="ecore:EClass" name="ActionParameterMetadata" eSuperTypes="#//NexusMetadata"/>
   <eClassifiers xsi:type="ecore:EClass" name="ActionMetadata" eSuperTypes="#//NexusMetadata"/>
   <eClassifiers xsi:type="ecore:EClass" name="ResourceValueMetadata" eSuperTypes="#//Metadata"/>
+  <eClassifiers xsi:type="ecore:EClass" name="FeatureCustomMetadataMap" instanceClassName="java.util.Map$Entry">
+    <eStructuralFeatures xsi:type="ecore:EAttribute" name="key" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
+    <eStructuralFeatures xsi:type="ecore:EReference" name="value" eType="#//FeatureCustomMetadata"
+        containment="true"/>
+  </eClassifiers>
 </ecore:EPackage>

--- a/core/models/provider/src/main/resources/model/sensinact.genmodel
+++ b/core/models/provider/src/main/resources/model/sensinact.genmodel
@@ -60,7 +60,6 @@
       <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference sensinact.ecore#//FeatureMetadata/value"/>
     </genClasses>
     <genClasses ecoreClass="sensinact.ecore#//FeatureCustomMetadata">
-      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute sensinact.ecore#//FeatureCustomMetadata/name"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute sensinact.ecore#//FeatureCustomMetadata/timestamp"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute sensinact.ecore#//FeatureCustomMetadata/value"/>
     </genClasses>
@@ -100,5 +99,9 @@
     <genClasses ecoreClass="sensinact.ecore#//ActionParameterMetadata"/>
     <genClasses ecoreClass="sensinact.ecore#//ActionMetadata"/>
     <genClasses ecoreClass="sensinact.ecore#//ResourceValueMetadata"/>
+    <genClasses ecoreClass="sensinact.ecore#//FeatureCustomMetadataMap">
+      <genFeatures createChild="false" ecoreFeature="ecore:EAttribute sensinact.ecore#//FeatureCustomMetadataMap/key"/>
+      <genFeatures property="None" children="true" createChild="true" ecoreFeature="ecore:EReference sensinact.ecore#//FeatureCustomMetadataMap/value"/>
+    </genClasses>
   </genPackages>
 </genmodel:GenModel>


### PR DESCRIPTION
We (@juergen-albert and me) move the extra FeatureCustomMetadata feature from a list with the name in the FeatureCustomMetadata to a map to avoid issues, e.g. when removing elements bei name and converting the list to the final output. In addition issues with unset timestamps were resolved.