### PR TITLE
Revert/fix getModelName from annotation

### DIFF
--- a/core/impl/src/main/java/org/eclipse/sensinact/core/model/nexus/emf/EMFUtil.java
+++ b/core/impl/src/main/java/org/eclipse/sensinact/core/model/nexus/emf/EMFUtil.java
@@ -50,8 +50,8 @@ import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.emf.ecore.xmi.impl.XMIResourceImpl;
 import org.eclipse.sensinact.model.core.provider.ActionMetadata;
 import org.eclipse.sensinact.model.core.provider.ActionParameterMetadata;
-import org.eclipse.sensinact.model.core.provider.MetadataValue;
 import org.eclipse.sensinact.model.core.provider.Metadata;
+import org.eclipse.sensinact.model.core.provider.MetadataValue;
 import org.eclipse.sensinact.model.core.provider.ModelMetadata;
 import org.eclipse.sensinact.model.core.provider.NexusMetadata;
 import org.eclipse.sensinact.model.core.provider.ProviderFactory;
@@ -153,14 +153,11 @@ public class EMFUtil {
         return result;
     }
 
-    public static MetadataValue createMetadataValue(Instant timestamp,
-            Object value) {
-        return handleMetadataValue(ProviderFactory.eINSTANCE.createMetadataValue(), timestamp,
-                value);
+    public static MetadataValue createMetadataValue(Instant timestamp, Object value) {
+        return handleMetadataValue(ProviderFactory.eINSTANCE.createMetadataValue(), timestamp, value);
     }
 
-    public static MetadataValue handleMetadataValue(MetadataValue customMetadata,
-            Instant timestamp, Object value) {
+    public static MetadataValue handleMetadataValue(MetadataValue customMetadata, Instant timestamp, Object value) {
         customMetadata.setTimestamp(timestamp);
         customMetadata.setValue(value);
         return customMetadata;
@@ -170,8 +167,8 @@ public class EMFUtil {
         for (Entry<String, String> entry : details.entrySet()) {
             EStructuralFeature eStructuralFeature = metadata.eClass().getEStructuralFeature(entry.getKey());
             if (eStructuralFeature instanceof EAttribute attribute) {
-                metadata.eSet(eStructuralFeature, EcoreUtil
-                        .createFromString(attribute.getEAttributeType(), entry.getValue()));
+                metadata.eSet(eStructuralFeature,
+                        EcoreUtil.createFromString(attribute.getEAttributeType(), entry.getValue()));
             } else {
                 metadata.getExtra().put(entry.getKey(), createMetadataValue(null, entry.getValue()));
             }
@@ -424,19 +421,33 @@ public class EMFUtil {
                 .orElseGet(() -> EcoreUtil.getID(eObject));
     }
 
+    /**
+     * Get the name of the model:
+     * <ol>
+     * <li>From the model {@link EAnnotation}</li>
+     * <li>From the {@link ModelMetadata#getOriginalName()}</li>
+     * <li>From the name of the {@link EClass}</li>
+     * </ol>
+     *
+     * @param model EClass of the model
+     * @return model name
+     */
     public static String getModelName(EClass model) {
+        EAnnotation modelAnnotation = model.getEAnnotation("model");
+        if (modelAnnotation != null) {
+            return model.getEAnnotation("model").getDetails().get("name");
+        }
         ModelMetadata metadata = (ModelMetadata) getModelMetadata(model);
         if (metadata != null) {
             return metadata.getOriginalName();
-        } else {
-            return model.getName();
         }
+        return model.getName();
     }
 
     /**
-     * TODO: we have to sanatize the name, so it fits the conventions of EMF
+     * TODO: we have to sanitize the name, so it fits the conventions of EMF
      *
-     * @param modelName the modelname to construct a URI from
+     * @param modelName the model name to construct a URI from
      * @return the constructed uri of the package, using the given basepackage
      */
     public static String constructPackageUri(String baseUri, String modelName) {

--- a/core/impl/src/test/java/org/eclipse/sensinact/core/emf/util/EMFUtilTest.java
+++ b/core/impl/src/test/java/org/eclipse/sensinact/core/emf/util/EMFUtilTest.java
@@ -17,11 +17,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.util.Map;
 
 import org.eclipse.emf.ecore.EcorePackage;
+import org.eclipse.sensinact.core.model.nexus.emf.EMFUtil;
 import org.eclipse.sensinact.gateway.geojson.GeoJsonObject;
 import org.eclipse.sensinact.gateway.geojson.GeoJsonType;
 import org.eclipse.sensinact.gateway.geojson.Point;
 import org.eclipse.sensinact.model.core.provider.ProviderPackage;
-import org.eclipse.sensinact.core.model.nexus.emf.EMFUtil;
+import org.eclipse.sensinact.model.core.testdata.TestdataPackage;
 import org.junit.jupiter.api.Test;
 
 public class EMFUtilTest {
@@ -73,4 +74,15 @@ public class EMFUtilTest {
         assertEquals(12, o);
     }
 
+    @Test
+    void testGetModelName() {
+        String modelName = EMFUtil.getModelName(TestdataPackage.Literals.TEST_SENSOR);
+        assertEquals("TestSensor", modelName);
+    }
+
+    @Test
+    void testGetModelNameAnnotation() {
+        String modelName = EMFUtil.getModelName(TestdataPackage.Literals.TEST_MODEL_WITH_ANNOTATION);
+        assertEquals("TestModel", modelName);
+    }
 }

--- a/core/models/testdata/src/main/resources/model/testdata.ecore
+++ b/core/models/testdata/src/main/resources/model/testdata.ecore
@@ -30,4 +30,9 @@
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="foo" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="bar" eType="ecore:EDataType http://www.eclipse.org/emf/2002/Ecore#//EString"/>
   </eClassifiers>
+  <eClassifiers xsi:type="ecore:EClass" name="TestModelWithAnnotation">
+    <eAnnotations source="model">
+      <details key="name" value="TestModel"/>
+    </eAnnotations>
+  </eClassifiers>
 </ecore:EPackage>

--- a/core/models/testdata/src/main/resources/model/testdata.genmodel
+++ b/core/models/testdata/src/main/resources/model/testdata.genmodel
@@ -31,5 +31,6 @@
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute testdata.ecore#//TestResource/foo"/>
       <genFeatures createChild="false" ecoreFeature="ecore:EAttribute testdata.ecore#//TestResource/bar"/>
     </genClasses>
+    <genClasses ecoreClass="testdata.ecore#//TestModelWithAnnotation"/>
   </genPackages>
 </genmodel:GenModel>


### PR DESCRIPTION
Just bring back the functionality to get an alternative model name from an EAnnotation.