### PR TITLE
Fix retrieving history entry of single observation

### DIFF
--- a/northbound/sensorthings/rest.gateway/src/main/java/org/eclipse/sensinact/sensorthings/sensing/rest/impl/ObservationsAccessImpl.java
+++ b/northbound/sensorthings/rest.gateway/src/main/java/org/eclipse/sensinact/sensorthings/sensing/rest/impl/ObservationsAccessImpl.java
@@ -51,9 +51,11 @@ public class ObservationsAccessImpl extends AbstractAccess implements Observatio
                     String provider = resourceSnapshot.getService().getProvider().getName();
                     String service = resourceSnapshot.getService().getName();
                     String resource = resourceSnapshot.getName();
+                    // +1 milli as 00:00:00.123456 (db) is always greater than 00:00:00.123000 (timestamp)
+                    Instant timestampPlusOneMilli = timestamp.plusMillis(1);
                     TimedValue<?> t = (TimedValue<?>) getSession().actOnResource(history, "history", "single",
-                            Map.of("provider", provider, "service", service, "resource", resource, "time", timestamp));
-                    if (timestamp.equals(t.getTimestamp())) {
+                            Map.of("provider", provider, "service", service, "resource", resource, "time", timestampPlusOneMilli));
+                    if (timestamp.equals(t.getTimestamp().truncatedTo(ChronoUnit.MILLIS))) {
                         result = DtoMapper.toObservation(getSession(), application, getMapper(),
                                 uriInfo, getExpansions(), resourceSnapshot, Optional.of(t));
                     }

--- a/northbound/sensorthings/rest.gateway/src/test/java/org/eclipse/sensinact/sensorthings/sensing/rest/integration/ObservationHistoryTest.java
+++ b/northbound/sensorthings/rest.gateway/src/test/java/org/eclipse/sensinact/sensorthings/sensing/rest/integration/ObservationHistoryTest.java
@@ -55,7 +55,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 
 public class ObservationHistoryTest extends AbstractIntegrationTest {
 
-    private static final Instant TS_2012 = Instant.parse("2012-01-01T00:00:00.00Z");
+    private static final Instant TS_2012 = Instant.parse("2012-01-01T01:23:45.123456Z");
 
     private static final TypeReference<ResultList<Observation>> RESULT_OBSERVATIONS = new TypeReference<ResultList<Observation>>() {
     };


### PR DESCRIPTION
I have found an issue in the SensorThing REST api. If I retrieve a list of observations with history entries, following the `@iot.selfLink` of any entry, ends in an 404 error. 
Loading the single resource starts with getting the timestamp from the observation id (e.g. 197a19b631b -> 2025-06-24T11:03:53.438Z) with this timestamp + provider + service + resource the history provider is requested to load the single resource. 
The `TimescaleDatabase` worker tries to load the suitable entry from the database
```sql
...
        AND RESOURCE = ('conflict') 
        AND TIME <= ('2025-06-24 13:03:53.438+02') 
        ORDER BY 
            TIME DESC 
        LIMIT 
            1
  ...
```
But the entries are stored with a more precise timestamp that includes microseconds  
time | seconds_micro | num | text | geo
------|-------|------|-----|-------
2025-06-24 13:03:53 | 53.438492 | (null) | false | (null)
2025-06-24 13:03:24  | 24.699655 | (null) | true | (null)

With the `<=` comparison the entry with the 2025-06-24 13:03:53.438492 timestamp is never loaded.
The worker loads no or the wrong entry. The afterwards timestamp check excludes the wrong entry and results in a 404.

I have added 1 millisecond to the request timestamp (2025-06-24 13:03:53.439+02) and truncated the microseconds in the afterwards timestamp check.