### PR TITLE
Handle explicit null match type values in Selection as EXACT

### DIFF
--- a/filters/resource.selector/src/main/java/org/eclipse/sensinact/filters/resource/selector/jackson/SelectionDeserializer.java
+++ b/filters/resource.selector/src/main/java/org/eclipse/sensinact/filters/resource/selector/jackson/SelectionDeserializer.java
@@ -13,6 +13,7 @@
 package org.eclipse.sensinact.filters.resource.selector.jackson;
 
 import java.io.IOException;
+import java.util.Optional;
 
 import org.eclipse.sensinact.filters.resource.selector.api.Selection;
 import org.eclipse.sensinact.filters.resource.selector.api.Selection.MatchType;
@@ -30,16 +31,22 @@ public class SelectionDeserializer extends AbstractSelectionDeserializer<Selecti
 
     @Override
     public Selection convert(JsonNode root, DeserializationContext ctxt) throws IOException {
-        return switch(root.getNodeType()) {
-            case STRING: yield new Selection(root.textValue(), MatchType.EXACT, false);
-            case OBJECT: yield new Selection(toString(root, "value", ctxt),
-                    ctxt.readTreeAsValue(root.get("type"), MatchType.class),
+        return switch (root.getNodeType()) {
+        case STRING:
+            yield new Selection(root.textValue(), MatchType.EXACT, false);
+        case OBJECT:
+            yield new Selection(toString(root, "value", ctxt),
+                    ctxt.readTreeAsValue(
+                            Optional.ofNullable(root.get("type")).map(n -> n.isNull() ? null : n).orElse(null),
+                            MatchType.class),
                     toBoolean(root, "negate", ctxt));
-            case NULL: yield null;
-            default:
-                ctxt.reportBadCoercion(this, Selection.class, root, "Selection must be a String or JSON object but was %s", root.getNodeType());
-                // Never reached
-                yield null;
+        case NULL:
+            yield null;
+        default:
+            ctxt.reportBadCoercion(this, Selection.class, root, "Selection must be a String or JSON object but was %s",
+                    root.getNodeType());
+            // Never reached
+            yield null;
         };
     }
 }

--- a/filters/resource.selector/src/test/java/org/eclipse/sensinact/gateway/filters/resource/selector/api/JsonSerializationTests.java
+++ b/filters/resource.selector/src/test/java/org/eclipse/sensinact/gateway/filters/resource/selector/api/JsonSerializationTests.java
@@ -22,6 +22,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 
+import org.eclipse.sensinact.filters.resource.selector.api.CompactResourceSelector;
 import org.eclipse.sensinact.filters.resource.selector.api.ResourceSelector;
 import org.eclipse.sensinact.filters.resource.selector.api.ResourceSelector.ProviderSelection;
 import org.eclipse.sensinact.filters.resource.selector.api.ResourceSelector.ResourceSelection;
@@ -46,6 +47,18 @@ class JsonSerializationTests {
 
     @Nested
     class CompactTests {
+        @Test
+        void explicitNull() throws Exception {
+            final String value = "{\"provider\":{\"value\":\"foobar\", \"type\": null},\"service\":{\"value\":\"admin\"}}";
+            CompactResourceSelector selector = mapper.readValue(value, CompactResourceSelector.class);
+            assertEquals("foobar", selector.provider().value());
+            assertEquals(MatchType.EXACT, selector.provider().type());
+            assertFalse(selector.provider().negate());
+            assertEquals("admin", selector.service().value());
+            assertEquals(MatchType.EXACT, selector.service().type());
+            assertFalse(selector.service().negate());
+        }
+
         @Test
         void compact() throws StreamReadException, DatabindException, IOException {
             ResourceSelector selector = mapper.readValue(selectorsFolder.resolve("compact.json").toFile(), ResourceSelector.class);


### PR DESCRIPTION
This fixes the `MismatchedInputException` thrown when an explicit null value is given as a selection match type.
