### PR TITLE
Notifications should contain the data really stored in model

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -1,7 +1,7 @@
 maven/mavencentral/biz.aQute.bnd/biz.aQute.bnd.annotation/6.4.0, Apache-2.0 OR EPL-2.0, approved, #6710
 maven/mavencentral/biz.aQute.bnd/biz.aQute.bnd.annotation/7.0.0, Apache-2.0 OR EPL-2.0, approved, #10946
 maven/mavencentral/biz.aQute.bnd/biz.aQute.bndlib/3.5.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.bugsnag/bugsnag/3.7.2, MIT, approved, #8921
+maven/mavencentral/com.bugsnag/bugsnag/3.8.0, MIT, approved, #22566
 maven/mavencentral/com.fasterxml.jackson.core/jackson-annotations/2.16.1, Apache-2.0, approved, #11606
 maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.16.1, Apache-2.0 AND MIT, approved, #11602
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.16.1, Apache-2.0, approved, #11605

--- a/core/impl/integration-test.bndrun
+++ b/core/impl/integration-test.bndrun
@@ -53,7 +53,6 @@
 	org.mockito.mockito-core;version='[5.10.0,5.10.1)',\
 	org.objenesis;version='[3.3.0,3.3.1)',\
 	org.opentest4j;version='[1.3.0,1.3.1)',\
-	org.osgi.service.cm;version='[1.6.1,1.6.2)',\
 	org.osgi.service.component;version='[1.5.0,1.5.1)',\
 	org.osgi.service.typedevent;version='[1.0.0,1.0.1)',\
 	org.osgi.test.common;version='[1.3.0,1.3.1)',\

--- a/core/impl/src/main/java/org/eclipse/sensinact/core/model/nexus/ModelNexus.java
+++ b/core/impl/src/main/java/org/eclipse/sensinact/core/model/nexus/ModelNexus.java
@@ -65,8 +65,8 @@ import org.eclipse.sensinact.core.twin.TimedValue;
 import org.eclipse.sensinact.core.whiteboard.impl.SensinactWhiteboard;
 import org.eclipse.sensinact.model.core.provider.Admin;
 import org.eclipse.sensinact.model.core.provider.DynamicProvider;
-import org.eclipse.sensinact.model.core.provider.MetadataValue;
 import org.eclipse.sensinact.model.core.provider.Metadata;
+import org.eclipse.sensinact.model.core.provider.MetadataValue;
 import org.eclipse.sensinact.model.core.provider.ModelMetadata;
 import org.eclipse.sensinact.model.core.provider.Provider;
 import org.eclipse.sensinact.model.core.provider.ProviderFactory;
@@ -421,16 +421,18 @@ public class ModelNexus {
             }
             metadata.setTimestamp(metaTimestamp);
 
+            final Object storedData;
             if (data == null || resourceType.isInstance(data)) {
-                service.eSet(resourceFeature, data);
+                storedData = data;
             } else {
-                service.eSet(resourceFeature, EMFUtil.convertToTargetType(resourceType, data));
+                storedData = EMFUtil.convertToTargetType(resourceType, data);
             }
+            service.eSet(resourceFeature, storedData);
 
-            Map<String, Object> newMetaData = EMFCompareUtil.extractMetadataMap(data, metadata, resourceFeature);
+            Map<String, Object> newMetaData = EMFCompareUtil.extractMetadataMap(storedData, metadata, resourceFeature);
 
             accumulator.resourceValueUpdate(packageUri, modelName, providerName, serviceName, resourceFeature.getName(),
-                    resourceType.getInstanceClass(), oldValue, data, newMetaData, metaTimestamp);
+                    resourceType.getInstanceClass(), oldValue, storedData, newMetaData, metaTimestamp);
             accumulator.metadataValueUpdate(packageUri, modelName, providerName, serviceName, resourceFeature.getName(),
                     oldMetaData, newMetaData, timestamp);
         } else {

--- a/core/impl/src/test/java/org/eclipse/sensinact/core/integration/EMFUpdateServiceTest.java
+++ b/core/impl/src/test/java/org/eclipse/sensinact/core/integration/EMFUpdateServiceTest.java
@@ -13,9 +13,9 @@
 package org.eclipse.sensinact.core.integration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.InvocationTargetException;
 import java.time.Instant;
@@ -170,8 +170,8 @@ public class EMFUpdateServiceTest {
             assertEquals("14 °C", getResourceValue("TestSensor", PROVIDER, SERVICE, RESOURCE));
             Instant current = getResourceTimestamp("TestSensor", PROVIDER, SERVICE, RESOURCE);
             assertNotNull(current);
-            assertTrue(before.isBefore(current));
-            assertTrue(after.isAfter(current));
+            assertFalse(before.isAfter(current));
+            assertFalse(after.isBefore(current));
 
             temp.setV1("13 °C");
             before = Instant.now();
@@ -182,8 +182,8 @@ public class EMFUpdateServiceTest {
             current = getResourceTimestamp("TestSensor", PROVIDER, SERVICE, RESOURCE);
             assertNotNull(current);
             after = Instant.now();
-            assertTrue(before.isBefore(current));
-            assertTrue(after.isAfter(current));
+            assertFalse(before.isAfter(current));
+            assertFalse(after.isBefore(current));
         }
 
         @Test

--- a/northbound/rest/src/test/java/org/eclipse/sensinact/northbound/rest/integration/ResourceAccessTest.java
+++ b/northbound/rest/src/test/java/org/eclipse/sensinact/northbound/rest/integration/ResourceAccessTest.java
@@ -285,7 +285,7 @@ public class ResourceAccessTest {
         dto.service = ADMIN;
         dto.resource = LOCATION;
         dto.type = Point.class;
-        dto.value = utils.convert(p, Map.class);
+        dto.value = p;
         utils.assertNotification(dto, queue.poll(1, TimeUnit.SECONDS));
 
         // Check access


### PR DESCRIPTION
Currently, the listeners are notified of a resource update with the value provided by the updater.
Instead, they should be notified with the converted value, when appliable.

The solves a class cast exception in org.eclipse.sensinact.core.snapshot.ResourceDataFilter (in the ICriterion file), as it expects admin/location to be a GeoJsonObject while being notified with a map.

Also fixed an integration test failing on Windows due to timestamp precision
