### PR TITLE
Query filters on database level

### DIFF
--- a/northbound/sensorthings/rest.api/src/main/java/org/eclipse/sensinact/sensorthings/sensing/rest/IFilterConstants.java
+++ b/northbound/sensorthings/rest.api/src/main/java/org/eclipse/sensinact/sensorthings/sensing/rest/IFilterConstants.java
@@ -20,8 +20,13 @@ public interface IFilterConstants {
     String PROP_FILTER_STRING = "sensinact.sensorthings.filter";
 
     /**
-     * Request context property holding the filter as a string
+     * Request context property holding the expand settings as a string
      */
     String EXPAND_SETTINGS_STRING = "sensinact.sensorthings.expand";
+
+    /**
+     * Request context property holding the skip value as a Integer
+     */
+    String SKIP_PROP = "org.eclipse.sensinact.sensorthings.sensing.rest.skip";
 
 }

--- a/northbound/sensorthings/rest.api/src/main/java/org/eclipse/sensinact/sensorthings/sensing/rest/filters/SkipFilter.java
+++ b/northbound/sensorthings/rest.api/src/main/java/org/eclipse/sensinact/sensorthings/sensing/rest/filters/SkipFilter.java
@@ -19,6 +19,7 @@ import java.util.List;
 
 import org.eclipse.sensinact.sensorthings.sensing.dto.ResultList;
 import org.eclipse.sensinact.sensorthings.sensing.dto.Self;
+import org.eclipse.sensinact.sensorthings.sensing.rest.IFilterConstants;
 
 import jakarta.annotation.Priority;
 import jakarta.ws.rs.container.ContainerRequestContext;
@@ -34,12 +35,11 @@ import jakarta.ws.rs.core.Response.Status;
 @Priority(ENTITY_CODER + 2)
 public class SkipFilter implements ContainerRequestFilter, ContainerResponseFilter {
 
-    static final String SKIP_PROP = "org.eclipse.sensinact.sensorthings.sensing.rest.skip";
 
     @Override
     public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext)
             throws IOException {
-        Integer skip = (Integer) requestContext.getProperty(SKIP_PROP);
+        Integer skip = (Integer) requestContext.getProperty(IFilterConstants.SKIP_PROP);
         if (skip == null) {
             return;
         }
@@ -80,7 +80,7 @@ public class SkipFilter implements ContainerRequestFilter, ContainerResponseFilt
                     .entity("The $skip parameter must be an integer greater than zero").build());
         }
 
-        requestContext.setProperty(SKIP_PROP, skip);
+        requestContext.setProperty(IFilterConstants.SKIP_PROP, skip);
     }
 
 }

--- a/northbound/sensorthings/rest.api/src/main/java/org/eclipse/sensinact/sensorthings/sensing/rest/filters/TopFilter.java
+++ b/northbound/sensorthings/rest.api/src/main/java/org/eclipse/sensinact/sensorthings/sensing/rest/filters/TopFilter.java
@@ -19,6 +19,7 @@ import java.util.List;
 
 import org.eclipse.sensinact.sensorthings.sensing.dto.ResultList;
 import org.eclipse.sensinact.sensorthings.sensing.dto.Self;
+import org.eclipse.sensinact.sensorthings.sensing.rest.IFilterConstants;
 import org.eclipse.sensinact.sensorthings.sensing.rest.annotation.PaginationLimit;
 
 import jakarta.annotation.Priority;
@@ -57,7 +58,7 @@ public class TopFilter implements ContainerRequestFilter, ContainerResponseFilte
             int size = resultList.value.size();
             resultList.value = resultList.value.subList(0, Math.min(top, size));
 
-            Integer skip = (Integer) requestContext.getProperty(SkipFilter.SKIP_PROP);
+            Integer skip = (Integer) requestContext.getProperty(IFilterConstants.SKIP_PROP);
             Integer nextSkip = (skip == null) ? top : top + skip;
             if (top < size) {
                 resultList.nextLink = requestContext.getUriInfo().getRequestUriBuilder()

--- a/northbound/sensorthings/rest.gateway/integration-test.bndrun
+++ b/northbound/sensorthings/rest.gateway/integration-test.bndrun
@@ -46,6 +46,8 @@
 	junit-platform-commons;version='[1.10.1,1.10.2)',\
 	junit-platform-engine;version='[1.10.1,1.10.2)',\
 	junit-platform-launcher;version='[1.10.1,1.10.2)',\
+	net.bytebuddy.byte-buddy;version='[1.14.11,1.14.12)',\
+	net.bytebuddy.byte-buddy-agent;version='[1.14.11,1.14.12)',\
 	org.antlr.antlr4-runtime;version='[4.12.0,4.12.1)',\
 	org.apache.aries.component-dsl.component-dsl;version='[1.2.2,1.2.3)',\
 	org.apache.aries.spifly.dynamic.framework.extension;version='[1.3.7,1.3.8)',\
@@ -61,8 +63,8 @@
 	org.eclipse.emf.common;version='[2.29.0,2.29.1)',\
 	org.eclipse.emf.ecore;version='[2.35.0,2.35.1)',\
 	org.eclipse.emf.ecore.xmi;version='[2.36.0,2.36.1)',\
-	org.eclipse.jetty.http;version='[11.0.13,11.0.14)',\
-	org.eclipse.jetty.server;version='[11.0.13,11.0.14)',\
+	org.eclipse.jetty.io;version='[11.0.13,11.0.14)',\
+	org.eclipse.jetty.security;version='[11.0.13,11.0.14)',\
 	org.eclipse.jetty.util;version='[11.0.13,11.0.14)',\
 	org.eclipse.osgitech.rest;version='[1.2.2,1.2.3)',\
 	org.eclipse.osgitech.rest.jetty;version='[1.2.2,1.2.3)',\
@@ -103,9 +105,11 @@
 	org.glassfish.jersey.media.jersey-media-jaxb;version='[3.1.3,3.1.4)',\
 	org.glassfish.jersey.media.jersey-media-sse;version='[3.1.3,3.1.4)',\
 	org.locationtech.spatial4j;version='[0.8.0,0.8.1)',\
+	org.mockito.junit-jupiter;version='[5.10.0,5.10.1)',\
+	org.mockito.mockito-core;version='[5.10.0,5.10.1)',\
 	org.objectweb.asm;version='[9.6.0,9.6.1)',\
+	org.objenesis;version='[3.3.0,3.3.1)',\
 	org.opentest4j;version='[1.3.0,1.3.1)',\
-	org.osgi.service.cm;version='[1.6.1,1.6.2)',\
 	org.osgi.service.component;version='[1.5.0,1.5.1)',\
 	org.osgi.service.jakartars;version='[2.0.0,2.0.1)',\
 	org.osgi.service.typedevent;version='[1.0.0,1.0.1)',\

--- a/northbound/sensorthings/rest.gateway/src/main/java/org/eclipse/sensinact/sensorthings/sensing/rest/impl/DatastreamsAccessImpl.java
+++ b/northbound/sensorthings/rest.gateway/src/main/java/org/eclipse/sensinact/sensorthings/sensing/rest/impl/DatastreamsAccessImpl.java
@@ -50,7 +50,7 @@ public class DatastreamsAccessImpl extends AbstractAccess implements Datastreams
     @Override
     public ResultList<Observation> getDatastreamObservations(String id) {
         return RootResourceAccessImpl.getObservationList(getSession(), application, getMapper(), uriInfo,
-                getExpansions(), validateAndGetResourceSnapshot(id), 0);
+                requestContext, validateAndGetResourceSnapshot(id));
     }
 
     @Override

--- a/northbound/sensorthings/rest.gateway/src/main/java/org/eclipse/sensinact/sensorthings/sensing/rest/impl/HistoryResourceHelper.java
+++ b/northbound/sensorthings/rest.gateway/src/main/java/org/eclipse/sensinact/sensorthings/sensing/rest/impl/HistoryResourceHelper.java
@@ -1,0 +1,125 @@
+/*********************************************************************
+* Copyright (c) 2023 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   Kentyou - initial implementation
+**********************************************************************/
+package org.eclipse.sensinact.sensorthings.sensing.rest.impl;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.sensinact.core.snapshot.ResourceSnapshot;
+import org.eclipse.sensinact.core.twin.TimedValue;
+import org.eclipse.sensinact.northbound.session.SensiNactSession;
+import org.eclipse.sensinact.sensorthings.sensing.dto.Observation;
+import org.eclipse.sensinact.sensorthings.sensing.dto.ResultList;
+import org.eclipse.sensinact.sensorthings.sensing.rest.ExpansionSettings;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.core.UriInfo;
+
+/**
+ * Helper class for accessing historical observation data from the history
+ * provider
+ */
+class HistoryResourceHelper {
+
+    private HistoryResourceHelper() {
+    }
+
+    @SuppressWarnings("unchecked")
+    static ResultList<Observation> loadHistoricalObservations(SensiNactSession userSession,
+            Application application, ObjectMapper mapper, UriInfo uriInfo, ExpansionSettings expansions,
+            ResourceSnapshot resourceSnapshot, int localResultLimit) {
+        ResultList<Observation> list = new ResultList<>();
+        list.value = new ArrayList<>();
+        String historyProvider = (String) application.getProperties().get("sensinact.history.provider");
+
+        if (historyProvider != null) {
+            Integer maxResults = (Integer) application.getProperties().get("sensinact.history.result.limit");
+
+            if (localResultLimit > 0) {
+                maxResults = Math.min(localResultLimit, maxResults);
+            }
+
+            Map<String, Object> params = initParameter(resourceSnapshot);
+            // Get count for the full dataset (for pagination metadata)
+            Long count = (Long) userSession.actOnResource(historyProvider, "history", "count", params);
+            list.count = count == null ? null : count > Integer.MAX_VALUE ? Integer.MAX_VALUE : count.intValue();
+
+            int skip = extractSkipParameter(uriInfo, params);
+            int top = extractTopParameter(uriInfo, params, maxResults);
+            extractOrderByParameter(uriInfo, params);
+
+            List<TimedValue<?>> timed;
+            do {
+                params.put("skip", skip);
+
+                timed = (List<TimedValue<?>>) userSession.actOnResource(historyProvider, "history", "rangeFiltered",
+                        params);
+                list.value.addAll(0, DtoMapper.toObservationList(userSession, application, mapper, uriInfo, expansions,
+                        resourceSnapshot, timed));
+                if (timed.isEmpty()) {
+                    break;
+                } else if (timed.size() == 500) {
+                    skip = skip + list.value.size();
+                }
+
+            } while (list.value.size() < count && list.value.size() < top);
+        }
+        return list;
+    }
+
+    private static void extractOrderByParameter(UriInfo uriInfo, Map<String, Object> params) {
+        List<String> orderbyParam = uriInfo.getQueryParameters().get("$orderby");
+        if (orderbyParam != null && !orderbyParam.isEmpty()) {
+            String orderByValue = orderbyParam.get(0);
+            String orderBy = orderByValue.toLowerCase().contains("desc") ? "desc" : "asc";
+            params.put("orderBy", orderBy);
+        }
+    }
+
+    private static int extractSkipParameter(UriInfo uriInfo, Map<String, Object> params) {
+        List<String> skipParam = uriInfo.getQueryParameters().get("$skip");
+        int skip = 0;
+        if (skipParam != null && !skipParam.isEmpty()) {
+            skip = Integer.parseInt(skipParam.get(0));
+            params.put("skip", skip);
+        }
+        return skip;
+    }
+
+    private static int extractTopParameter(UriInfo uriInfo, Map<String, Object> params, Integer maxResults) {
+        List<String> topParam = uriInfo.getQueryParameters().get("$top");
+        int top;
+        if (topParam != null && !topParam.isEmpty()) {
+            top = Math.min(Integer.parseInt(topParam.get(0)), maxResults != null ? maxResults : 500);
+        } else {
+            top = maxResults;
+        }
+        params.put("top", top);
+        return top;
+    }
+
+    private static Map<String, Object> initParameter(ResourceSnapshot resourceSnapshot) {
+        String provider = resourceSnapshot.getService().getProvider().getName();
+        String service = resourceSnapshot.getService().getName();
+        String resource = resourceSnapshot.getName();
+        Map<String, Object> params = new HashMap<>();
+        params.put("provider", provider);
+        params.put("service", service);
+        params.put("resource", resource);
+        return params;
+    }
+}

--- a/northbound/sensorthings/rest.gateway/src/main/java/org/eclipse/sensinact/sensorthings/sensing/rest/impl/ObservationsAccessImpl.java
+++ b/northbound/sensorthings/rest.gateway/src/main/java/org/eclipse/sensinact/sensorthings/sensing/rest/impl/ObservationsAccessImpl.java
@@ -93,7 +93,7 @@ public class ObservationsAccessImpl extends AbstractAccess implements Observatio
     @Override
     public ResultList<Observation> getObservationDatastreamObservations(String id) {
         return RootResourceAccessImpl.getObservationList(getSession(), application, getMapper(), uriInfo,
-                getExpansions(), validateAndGetResourceSnapshot(id), 0);
+                requestContext, validateAndGetResourceSnapshot(id));
     }
 
     @Override

--- a/northbound/sensorthings/rest.gateway/src/main/java/org/eclipse/sensinact/sensorthings/sensing/rest/impl/ObservedPropertiesAccessImpl.java
+++ b/northbound/sensorthings/rest.gateway/src/main/java/org/eclipse/sensinact/sensorthings/sensing/rest/impl/ObservedPropertiesAccessImpl.java
@@ -65,7 +65,7 @@ public class ObservedPropertiesAccessImpl extends AbstractAccess implements Obse
             throw new NotFoundException();
         }
         return RootResourceAccessImpl.getObservationList(getSession(), application, getMapper(), uriInfo,
-                getExpansions(), validateAndGetResourceSnapshot(id), 0);
+                requestContext, validateAndGetResourceSnapshot(id));
     }
 
     @Override

--- a/northbound/sensorthings/rest.gateway/src/main/java/org/eclipse/sensinact/sensorthings/sensing/rest/impl/SensorsAccessImpl.java
+++ b/northbound/sensorthings/rest.gateway/src/main/java/org/eclipse/sensinact/sensorthings/sensing/rest/impl/SensorsAccessImpl.java
@@ -61,7 +61,7 @@ public class SensorsAccessImpl extends AbstractAccess implements SensorsAccess {
             throw new NotFoundException();
         }
         return RootResourceAccessImpl.getObservationList(getSession(), application, getMapper(), uriInfo,
-                getExpansions(), validateAndGetResourceSnapshot(id), 0);
+                requestContext, validateAndGetResourceSnapshot(id));
     }
 
     @Override

--- a/northbound/sensorthings/rest.gateway/src/main/java/org/eclipse/sensinact/sensorthings/sensing/rest/impl/ThingsAccessImpl.java
+++ b/northbound/sensorthings/rest.gateway/src/main/java/org/eclipse/sensinact/sensorthings/sensing/rest/impl/ThingsAccessImpl.java
@@ -76,7 +76,7 @@ public class ThingsAccessImpl extends AbstractAccess implements ThingsAccess {
         }
 
         return RootResourceAccessImpl.getObservationList(getSession(), application, getMapper(), uriInfo,
-                getExpansions(), validateAndGetResourceSnapshot(id2), 0);
+                requestContext, validateAndGetResourceSnapshot(id2));
     }
 
     @Override

--- a/northbound/sensorthings/rest.gateway/src/test/java/org/eclipse/sensinact/sensorthings/sensing/rest/impl/HistoryResourceHelperTest.java
+++ b/northbound/sensorthings/rest.gateway/src/test/java/org/eclipse/sensinact/sensorthings/sensing/rest/impl/HistoryResourceHelperTest.java
@@ -1,0 +1,363 @@
+/*********************************************************************
+* Copyright (c) 2023 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   Kentyou - initial implementation
+**********************************************************************/
+package org.eclipse.sensinact.sensorthings.sensing.rest.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.sensinact.core.snapshot.ProviderSnapshot;
+import org.eclipse.sensinact.core.snapshot.ResourceSnapshot;
+import org.eclipse.sensinact.core.snapshot.ServiceSnapshot;
+import org.eclipse.sensinact.core.twin.DefaultTimedValue;
+import org.eclipse.sensinact.core.twin.TimedValue;
+import org.eclipse.sensinact.northbound.session.SensiNactSession;
+import org.eclipse.sensinact.sensorthings.sensing.dto.Observation;
+import org.eclipse.sensinact.sensorthings.sensing.dto.ResultList;
+import org.eclipse.sensinact.sensorthings.sensing.rest.ExpansionSettings;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.UriBuilder;
+import jakarta.ws.rs.core.UriInfo;
+
+@ExtendWith(MockitoExtension.class)
+class HistoryResourceHelperTest {
+
+    @Mock
+    private SensiNactSession userSession;
+
+    @Mock
+    private Application application;
+
+    @Mock
+    private ObjectMapper mapper;
+
+    @Mock
+    private UriInfo uriInfo;
+
+    @Mock
+    private ExpansionSettings expansions;
+
+    @Mock
+    private ResourceSnapshot resourceSnapshot;
+
+    @Mock
+    private ServiceSnapshot serviceSnapshot;
+
+    @Mock
+    private ProviderSnapshot providerSnapshot;
+
+    @Mock
+    private UriBuilder uriBuilder;
+
+    private MultivaluedMap<String, String> queryParameters;
+
+    @BeforeEach
+    void setUp() {
+        queryParameters = new MultivaluedHashMap<>();
+    }
+
+    // Helper method to verify parameter maps contain expected basic parameters
+    private Map<String, Object> hasBasicParams() {
+        return argThat(params ->
+            params != null &&
+            "testProvider".equals(params.get("provider")) &&
+            "testService".equals(params.get("service")) &&
+            "testResource".equals(params.get("resource"))
+        );
+    }
+
+    // Helper method to verify parameter maps contain expected parameters with specific values
+    private Map<String, Object> hasParams(Object... expectedParams) {
+        return argThat(params -> {
+            if (params == null) return false;
+
+            // Check basic parameters
+            if (!"testProvider".equals(params.get("provider")) ||
+                !"testService".equals(params.get("service")) ||
+                !"testResource".equals(params.get("resource"))) {
+                return false;
+            }
+
+            // Check additional expected parameters in pairs (key, value)
+            for (int i = 0; i < expectedParams.length; i += 2) {
+                String key = (String) expectedParams[i];
+                Object expectedValue = expectedParams[i + 1];
+                if (!expectedValue.equals(params.get(key))) {
+                    return false;
+                }
+            }
+            return true;
+        });
+    }
+
+    private void setupResourceSnapshotMocks() {
+        when(uriInfo.getQueryParameters()).thenReturn(queryParameters);
+        when(resourceSnapshot.getService()).thenReturn(serviceSnapshot);
+        when(serviceSnapshot.getProvider()).thenReturn(providerSnapshot);
+        when(providerSnapshot.getName()).thenReturn("testProvider");
+        when(serviceSnapshot.getName()).thenReturn("testService");
+        when(resourceSnapshot.getName()).thenReturn("testResource");
+    }
+
+    @Nested
+    @DisplayName("History Provider Configuration")
+    class HistoryProviderConfiguration {
+
+        private void setupUriBuilder(Instant timestamp) {
+            when(uriInfo.getBaseUriBuilder()).thenReturn(uriBuilder);
+            when(uriBuilder.path(anyString())).thenReturn(uriBuilder);
+            when(uriBuilder.uri(anyString())).thenReturn(uriBuilder);
+            String timestampString = Long.toString(timestamp.toEpochMilli(), 16);
+            when(uriBuilder.resolveTemplate("id", "testProvider~testService~testResource~" + timestampString))
+                    .thenReturn(uriBuilder);
+            when(uriBuilder.build(any(Object[].class))).thenReturn(java.net.URI.create("http://test.com/test"));
+            when(uriBuilder.build()).thenReturn(java.net.URI.create("http://test.com/test"));
+        }
+
+        @Test
+        @DisplayName("Should return empty result when no history provider is configured")
+        void noHistoryProvider() {
+            when(application.getProperties()).thenReturn(Map.of());
+
+            ResultList<Observation> result = HistoryResourceHelper.loadHistoricalObservations(userSession,
+                    application, mapper, uriInfo, expansions, resourceSnapshot, 0);
+
+            assertNotNull(result);
+            assertTrue(result.value.isEmpty());
+        }
+
+        @Test
+        @DisplayName("Should process historical data when history provider is configured")
+        void withHistoryProvider() {
+            Instant now = Instant.now();
+            setupResourceSnapshotMocks();
+            setupUriBuilder(now);
+            String historyProvider = "test-history-provider";
+            Integer maxResults = 1000;
+            Long count = 5L;
+
+            Map<String, Object> appProperties = Map.of("sensinact.history.provider", historyProvider,
+                    "sensinact.history.result.limit", maxResults);
+            when(application.getProperties()).thenReturn(appProperties);
+
+            when(userSession.actOnResource(eq(historyProvider), eq("history"), eq("count"), hasBasicParams()))
+                    .thenReturn(count);
+
+            List<TimedValue<?>> timedValues = Arrays.asList(new DefaultTimedValue<>("value1", now),
+                    new DefaultTimedValue<>("value2", now));
+            when(userSession.actOnResource(eq(historyProvider), eq("history"), eq("rangeFiltered"), hasBasicParams()))
+                    .thenReturn(timedValues);
+
+            ResultList<Observation> result = HistoryResourceHelper.loadHistoricalObservations(userSession,
+                    application, mapper, uriInfo, expansions, resourceSnapshot, 0);
+
+            assertNotNull(result);
+            assertEquals(count.intValue(), result.count.intValue());
+            verify(userSession).actOnResource(eq(historyProvider), eq("history"), eq("count"), hasBasicParams());
+            verify(userSession, times(3)).actOnResource(eq(historyProvider), eq("history"), eq("rangeFiltered"), hasBasicParams());
+        }
+
+        @Test
+        @DisplayName("Should apply local result limit when provided")
+        void withLocalResultLimit() {
+            setupResourceSnapshotMocks();
+            String historyProvider = "test-history-provider";
+            Integer maxResults = 1000;
+            int localResultLimit = 100;
+
+            Map<String, Object> appProperties = Map.of("sensinact.history.provider", historyProvider,
+                    "sensinact.history.result.limit", maxResults);
+            when(application.getProperties()).thenReturn(appProperties);
+            when(userSession.actOnResource(eq(historyProvider), eq("history"), eq("count"), hasBasicParams())).thenReturn(50L);
+            when(userSession.actOnResource(eq(historyProvider), eq("history"), eq("rangeFiltered"), hasBasicParams()))
+                    .thenReturn(Arrays.asList());
+
+            HistoryResourceHelper.loadHistoricalObservations(userSession, application, mapper, uriInfo, expansions,
+                    resourceSnapshot, localResultLimit);
+
+            verify(userSession).actOnResource(eq(historyProvider), eq("history"), eq("rangeFiltered"), hasBasicParams());
+        }
+    }
+
+    @Nested
+    @DisplayName("Query Parameter Handling")
+    class QueryParameterHandling {
+
+        private void setupHistoryProvider() {
+            setupResourceSnapshotMocks();
+            String historyProvider = "test-history-provider";
+            Map<String, Object> appProperties = Map.of("sensinact.history.provider", historyProvider,
+                    "sensinact.history.result.limit", 1000);
+            when(application.getProperties()).thenReturn(appProperties);
+            when(userSession.actOnResource(eq(historyProvider), eq("history"), eq("count"), hasBasicParams())).thenReturn(50L);
+            when(userSession.actOnResource(eq(historyProvider), eq("history"), eq("rangeFiltered"), hasBasicParams()))
+                    .thenReturn(Arrays.asList());
+        }
+
+        @Test
+        @DisplayName("Should extract and apply $top parameter")
+        void topParameter() {
+            // Given
+            queryParameters.add("$top", "10");
+            setupHistoryProvider();
+
+            // When
+            HistoryResourceHelper.loadHistoricalObservations(userSession, application, mapper, uriInfo, expansions,
+                    resourceSnapshot, 0);
+
+            // Then
+            verify(userSession).actOnResource(eq("test-history-provider"), eq("history"), eq("rangeFiltered"),
+                    hasParams("top", 10, "skip", 0));
+        }
+
+        @Test
+        @DisplayName("Should extract and apply $skip parameter")
+        void skipParameter() {
+            // Given
+            queryParameters.add("$skip", "5");
+            setupHistoryProvider();
+
+            // When
+            HistoryResourceHelper.loadHistoricalObservations(userSession, application, mapper, uriInfo, expansions,
+                    resourceSnapshot, 0);
+
+            // Then
+            verify(userSession).actOnResource(eq("test-history-provider"), eq("history"), eq("rangeFiltered"),
+                    hasParams("top", 1000, "skip", 5));
+        }
+
+        @Test
+        @DisplayName("Should extract and apply $orderby ascending")
+        void orderByAscending() {
+            // Given
+            queryParameters.add("$orderby", "phenomenonTime asc");
+            setupHistoryProvider();
+
+            // When
+            HistoryResourceHelper.loadHistoricalObservations(userSession, application, mapper, uriInfo, expansions,
+                    resourceSnapshot, 0);
+
+            // Then
+            verify(userSession).actOnResource(eq("test-history-provider"), eq("history"), eq("rangeFiltered"),
+                    hasParams("top", 1000, "skip", 0, "orderBy", "asc"));
+        }
+
+        @Test
+        @DisplayName("Should extract and apply $orderby descending")
+        void orderByDescending() {
+            // Given
+            queryParameters.add("$orderby", "phenomenonTime desc");
+            setupHistoryProvider();
+
+            // When
+            HistoryResourceHelper.loadHistoricalObservations(userSession, application, mapper, uriInfo, expansions,
+                    resourceSnapshot, 0);
+
+            // Then
+            verify(userSession).actOnResource(eq("test-history-provider"), eq("history"), eq("rangeFiltered"),
+                    hasParams("top", 1000, "skip", 0, "orderBy", "desc"));
+        }
+
+        @Test
+        @DisplayName("Should handle all query parameters together")
+        void allParametersTogether() {
+            // Given
+            queryParameters.add("$top", "20");
+            queryParameters.add("$skip", "10");
+            queryParameters.add("$orderby", "phenomenonTime desc");
+            setupHistoryProvider();
+
+            // When
+            ResultList<Observation> result = HistoryResourceHelper.loadHistoricalObservations(userSession,
+                    application, mapper, uriInfo, expansions, resourceSnapshot, 0);
+
+            // Then
+            assertNotNull(result);
+            assertEquals(50, result.count.intValue());
+            verify(userSession).actOnResource(eq("test-history-provider"), eq("history"), eq("count"), hasBasicParams());
+            verify(userSession).actOnResource(eq("test-history-provider"), eq("history"), eq("rangeFiltered"),
+                    hasParams("top", 20, "skip", 10, "orderBy", "desc"));
+        }
+    }
+
+    @Nested
+    @DisplayName("Edge Cases")
+    class EdgeCases {
+
+        @Test
+        @DisplayName("Should handle count exceeding Integer.MAX_VALUE")
+        void countExceedsIntegerMax() {
+            setupResourceSnapshotMocks();
+            String historyProvider = "test-history-provider";
+            Long largeCount = (long) Integer.MAX_VALUE + 1;
+
+            Map<String, Object> appProperties = Map.of("sensinact.history.provider", historyProvider,
+                    "sensinact.history.result.limit", 1000);
+            when(application.getProperties()).thenReturn(appProperties);
+            when(userSession.actOnResource(eq(historyProvider), eq("history"), eq("count"), hasBasicParams()))
+                    .thenReturn(largeCount);
+            when(userSession.actOnResource(eq(historyProvider), eq("history"), eq("rangeFiltered"), hasBasicParams()))
+                    .thenReturn(Arrays.asList());
+
+            ResultList<Observation> result = HistoryResourceHelper.loadHistoricalObservations(userSession,
+                    application, mapper, uriInfo, expansions, resourceSnapshot, 0);
+
+            assertNotNull(result);
+            assertEquals(Integer.MAX_VALUE, result.count.intValue());
+        }
+
+        @Test
+        @DisplayName("Should handle null count from history provider")
+        void nullCount() {
+            setupResourceSnapshotMocks();
+            String historyProvider = "test-history-provider";
+
+            Map<String, Object> appProperties = Map.of("sensinact.history.provider", historyProvider,
+                    "sensinact.history.result.limit", 1000);
+            when(application.getProperties()).thenReturn(appProperties);
+            when(userSession.actOnResource(eq(historyProvider), eq("history"), eq("count"), hasBasicParams())).thenReturn(null);
+            when(userSession.actOnResource(eq(historyProvider), eq("history"), eq("rangeFiltered"), hasBasicParams()))
+                    .thenReturn(Arrays.asList());
+
+            ResultList<Observation> result = HistoryResourceHelper.loadHistoricalObservations(userSession,
+                    application, mapper, uriInfo, expansions, resourceSnapshot, 0);
+
+            assertNotNull(result);
+            assertEquals(null, result.count);
+        }
+    }
+}

--- a/northbound/sensorthings/rest.gateway/src/test/java/org/eclipse/sensinact/sensorthings/sensing/rest/integration/ObservationHistoryTest.java
+++ b/northbound/sensorthings/rest.gateway/src/test/java/org/eclipse/sensinact/sensorthings/sensing/rest/integration/ObservationHistoryTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.abort;
 
+import java.net.URLEncoder;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
@@ -248,8 +249,8 @@ public class ObservationHistoryTest extends AbstractIntegrationTest {
         for (int i = 0; i < 4000; i++) {
             createResource("foo", "bar", "foobar", Integer.valueOf(i), TS_2012.plus(ofDays(i)));
         }
-        // 1006: 1000 updates + history provider name & model & modelPackageUri + foo
-        // provider name & modelUri
+        // 1008: 1000 updates + history provider name & description & model & modelPackageUri + foo
+        // provider name & description &  modelUri
         waitForRowCount("sensinact.text_data", 1008);
         waitForRowCount("sensinact.numeric_data", 4000);
 
@@ -257,7 +258,7 @@ public class ObservationHistoryTest extends AbstractIntegrationTest {
                 RESULT_OBSERVATIONS);
 
         assertEquals(1000, observations.count);
-        assertEquals(500, observations.value.size());
+        assertEquals(500, observations.value.size()); //Is this 500 because of https://eclipse-sensinact.readthedocs.io/en/latest/southbound/history/history.html??
         assertNotNull(observations.nextLink);
 
         for (int i = 0; i < 500; i++) {
@@ -278,7 +279,7 @@ public class ObservationHistoryTest extends AbstractIntegrationTest {
             assertEquals(String.valueOf(i + 500), observations.value.get(i).result);
         }
 
-        observations = utils.queryJson("/Datastreams(foo~bar~foobar)/Observations?$count=true", RESULT_OBSERVATIONS);
+        observations = utils.queryJson("/Datastreams(foo~bar~foobar)/Observations?$count=true&$skip=1000", RESULT_OBSERVATIONS);
         assertEquals(4000, observations.count);
         assertEquals(500, observations.value.size());
         assertNotNull(observations.nextLink);

--- a/southbound/history/history-api/src/main/java/org/eclipse/sensinact/gateway/southbound/history/api/HistoricalQueries.java
+++ b/southbound/history/history-api/src/main/java/org/eclipse/sensinact/gateway/southbound/history/api/HistoricalQueries.java
@@ -73,6 +73,37 @@ public interface HistoricalQueries {
             @ActParam("toTime") ZonedDateTime toTime, @ActParam("skip") Integer skip);
 
     /**
+     * Return a list of values that a resource had between the given times with
+     * SensorThings API query parameter support for efficient database-level filtering.
+     *
+     * This method extends the basic range query with support for:
+     * - $top (limit): Maximum number of results to return
+     * - $orderby: Ordering of results (asc/desc by time)
+     * - Combined with existing fromTime/toTime/skip parameters
+     *
+     * @param provider the provider name
+     * @param service  the service name
+     * @param resource the resource name
+     * @param fromTime the time to start from. If <code>null</code> then the latest
+     *                 values before <code>toTime</code> will be returned
+     * @param toTime   the time to finish at. If <code>null</code> then there is no
+     *                 finishing time limit.
+     * @param skip     the number of values to skip in the result set
+     * @param top      the maximum number of results to return (SensorThings $top)
+     * @param orderBy  the ordering directive, "asc" or "desc" (SensorThings $orderby)
+     * @return A {@link List&lt;TimedValue&gt;} of results ordered according to orderBy parameter
+     */
+    @ACT(model = "sensiNactHistory", service = "history", resource = "rangeFiltered")
+    List<TimedValue<?>> getValueRangeFiltered(@ActParam("provider") String provider,
+            @ActParam("service") String service,
+            @ActParam("resource") String resource,
+            @ActParam("fromTime") ZonedDateTime fromTime,
+            @ActParam("toTime") ZonedDateTime toTime,
+            @ActParam("skip") Integer skip,
+            @ActParam("top") Integer top,
+            @ActParam("orderBy") String orderBy);
+
+    /**
      * Get the number of stored values for a given resource
      *
      * @param provider

--- a/southbound/http/http-callback-whiteboard/src/test/java/org/eclipse/sensinact/gateway/southbound/http/callback/integration/HttpCallbackWhiteboardTest.java
+++ b/southbound/http/http-callback-whiteboard/src/test/java/org/eclipse/sensinact/gateway/southbound/http/callback/integration/HttpCallbackWhiteboardTest.java
@@ -34,8 +34,11 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.osgi.framework.BundleContext;
 import org.osgi.test.common.annotation.InjectBundleContext;
+import org.osgi.test.common.annotation.InjectService;
 import org.osgi.test.common.annotation.Property;
 import org.osgi.test.common.annotation.config.WithConfiguration;
+
+import jakarta.servlet.Servlet;
 
 @MockitoSettings
 public class HttpCallbackWhiteboardTest {
@@ -46,15 +49,16 @@ public class HttpCallbackWhiteboardTest {
     @WithConfiguration(pid = "org.apache.felix.http", location = "?", properties = {
             @Property(key = "org.osgi.service.http.port", value = "8234"),
             @Property(key = "org.apache.felix.http.host", value = "127.0.0.1") })
-    @WithConfiguration(pid = "sensinact.http.callback.whiteboard", location = "?", properties = {})
+    @WithConfiguration(pid = "sensinact.http.callback.whiteboard", location = "?", properties = {
+            @Property(key = "id", value = "test") })
     @Test
-    void basicWhiteboard(@InjectBundleContext BundleContext context) throws Exception {
-
+    void basicWhiteboard(@InjectBundleContext BundleContext context,
+            @InjectService(timeout = 5000, filter = "(id=test)") Servlet whiteboard) throws Exception {
         context.registerService(HttpCallback.class, callback, null);
 
         ArgumentCaptor<String> stringCaptor = ArgumentCaptor.forClass(String.class);
 
-        Mockito.verify(callback, Mockito.timeout(1000)).activate(stringCaptor.capture());
+        Mockito.verify(callback, Mockito.timeout(5000)).activate(stringCaptor.capture());
 
         String uri = stringCaptor.getValue();
 
@@ -83,9 +87,11 @@ public class HttpCallbackWhiteboardTest {
     @WithConfiguration(pid = "org.apache.felix.http", location = "?", properties = {
             @Property(key = "org.osgi.service.http.port", value = "8235"),
             @Property(key = "org.apache.felix.http.host", value = "127.0.0.1") })
-    @WithConfiguration(pid = "sensinact.http.callback.whiteboard", location = "?", properties = @Property(key = "base.uri", value = "http://foo.com/bar"))
+    @WithConfiguration(pid = "sensinact.http.callback.whiteboard", location = "?", properties = {
+            @Property(key = "id", value = "test"), @Property(key = "base.uri", value = "http://foo.com/bar") })
     @Test
-    void customBaseUri(@InjectBundleContext BundleContext context) throws Exception {
+    void customBaseUri(@InjectBundleContext BundleContext context,
+            @InjectService(timeout = 5000, filter = "(id=test)") Servlet whiteboard) throws Exception {
 
         context.registerService(HttpCallback.class, callback, null);
 

--- a/southbound/rules/rules.impl/src/test/java/org/eclipse/sensinact/southbound/rules/impl/integration/RulesWhiteboardIntegrationTest.java
+++ b/southbound/rules/rules.impl/src/test/java/org/eclipse/sensinact/southbound/rules/impl/integration/RulesWhiteboardIntegrationTest.java
@@ -116,12 +116,12 @@ public class RulesWhiteboardIntegrationTest {
         push.pushUpdate(makeRc("temperature", "Temp1", "sensor", "temperature", 12)).getValue();
 
         // Called once and not again
-        Mockito.verify(rule, Mockito.after(100)).evaluate(Mockito.argThat(hasProviders("Temp1")), Mockito.notNull());
+        Mockito.verify(rule, Mockito.after(500)).evaluate(Mockito.argThat(hasProviders("Temp1")), Mockito.notNull());
 
         push.pushUpdate(makeRc("temperature", "Temp2", "sensor", "temperature", 42)).getValue();
 
         // Not called for other updates
-        Mockito.verify(rule, Mockito.after(100)).evaluate(Mockito.anyList(), Mockito.any());
+        Mockito.verify(rule, Mockito.after(500)).evaluate(Mockito.anyList(), Mockito.any());
     }
 
     @Test
@@ -148,12 +148,12 @@ public class RulesWhiteboardIntegrationTest {
         push.pushUpdate(makeRc("temperature", "Temp5", "sensor", "temperature", 12)).getValue();
 
         // Called once and not again
-        Mockito.verify(rule, Mockito.after(100)).evaluate(Mockito.argThat(hasProviders("Temp5")), Mockito.notNull());
+        Mockito.verify(rule, Mockito.after(500)).evaluate(Mockito.argThat(hasProviders("Temp5")), Mockito.notNull());
 
         push.pushUpdate(makeRc("temperature", "Temp2", "sensor", "temperature", 42)).getValue();
 
         // Not called for other updates
-        Mockito.verify(rule, Mockito.after(100)).evaluate(Mockito.anyList(), Mockito.any());
+        Mockito.verify(rule, Mockito.after(500)).evaluate(Mockito.anyList(), Mockito.any());
     }
 
     private ArgumentMatcher<List<ProviderSnapshot>> hasProviders(String... names) {


### PR DESCRIPTION
Limiting the result to 5 elements with the query parameter $top=5, but gathering hundreds or thousands elements from db and filtering at the end on the REST API level, isn't a good idea.
For a better performance I moved the handling of some REST query parameters (skip, top, orderby) to the TimescaleDB history provider. 
