### PR TITLE
Protect snapshot from null timestamp in query handler

### DIFF
--- a/northbound/query-handler-impl/src/main/java/org/eclipse/sensinact/northbound/query/impl/QueryHandler.java
+++ b/northbound/query-handler-impl/src/main/java/org/eclipse/sensinact/northbound/query/impl/QueryHandler.java
@@ -436,7 +436,8 @@ public class QueryHandler implements IQueryHandler {
                             SnapshotResourceDTO resourceDTO = new SnapshotResourceDTO();
                             resourceDTO.name = resourceSnapshot.getName();
                             resourceDTO.type = resourceSnapshot.getType().getName();
-                            resourceDTO.timestamp = resourceSnapshot.getValue().getTimestamp().toEpochMilli();
+                            resourceDTO.timestamp = Optional.ofNullable(resourceSnapshot.getValue().getTimestamp())
+                                    .map(Instant::toEpochMilli).orElse(0L);
                             resourceDTO.value = resourceSnapshot.getValue().getValue();
                             if (query.includeMetadata) {
                                 resourceDTO.attributes = generateMetadataDescriptions(resourceSnapshot.getMetadata());


### PR DESCRIPTION
Check if TimedValue.getTimestamp() is not null before calling toEpocMillis().
The timestamp can be null when the resource is managed via the EMF API but no timestamp has explicitly been set.

As the result is a `long`, we might want to set it to 0.