### PR TITLE
Added Ant call to generated files EOL to LF

### DIFF
--- a/southbound/sensorthings/sensing.rest/pom.xml
+++ b/southbound/sensorthings/sensing.rest/pom.xml
@@ -117,6 +117,25 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>fix-eol</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <target>
+                <fixcrlf srcdir="src/main/java/org/eclipse/sensinact/southbound/sensorthings/model"
+                  eol="unix" />
+              </target>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
On Windows, EMF generated Java files with CRLF line endings, which are seen as changes by Git.
This PR proposes a solution to force generated files to have LF endings.
