### PR TITLE
Jackson 3 follow-up

### DIFF
--- a/core/geo-json/src/main/java/org/eclipse/sensinact/gateway/geojson/Coordinates.java
+++ b/core/geo-json/src/main/java/org/eclipse/sensinact/gateway/geojson/Coordinates.java
@@ -32,7 +32,7 @@ public record Coordinates(double longitude, double latitude, double elevation) {
     /**
      * A ready made marker for an empty point using NaN for all coordinate values.
      * This will (de)serialize to/from an empty array in GeoJSON as described in
-     * Section 3.1 of the GeoJSON specifcation:
+     * Section 3.1 of the GeoJSON specification:
      * <p>
      * <i>GeoJSON processors MAY interpret Geometry objects with
      * empty "coordinates" arrays as null objects.</i>

--- a/core/geo-json/src/main/java/org/eclipse/sensinact/gateway/geojson/internal/CoordinatesDeserializer.java
+++ b/core/geo-json/src/main/java/org/eclipse/sensinact/gateway/geojson/internal/CoordinatesDeserializer.java
@@ -26,7 +26,6 @@ import tools.jackson.databind.exc.MismatchedInputException;
  * <a href="https://tools.ietf.org/html/rfc7946#section-3.1.1">the GeoJSON
  * specification</a>
  */
-@SuppressWarnings("serial")
 public class CoordinatesDeserializer extends StdNodeBasedDeserializer<Coordinates> {
 
     public CoordinatesDeserializer() {

--- a/core/geo-json/src/main/java/org/eclipse/sensinact/gateway/geojson/internal/CoordinatesSerializer.java
+++ b/core/geo-json/src/main/java/org/eclipse/sensinact/gateway/geojson/internal/CoordinatesSerializer.java
@@ -25,7 +25,6 @@ import tools.jackson.databind.ser.std.StdSerializer;
  * <a href="https://tools.ietf.org/html/rfc7946#section-3.1.1">the GeoJSON
  * specification</a>
  */
-@SuppressWarnings("serial")
 public class CoordinatesSerializer extends StdSerializer<Coordinates> {
 
     private static final double[] EMPTY = new double[0];

--- a/northbound/rest/src/main/java/org/eclipse/sensinact/northbound/rest/impl/JsonMapperProvider.java
+++ b/northbound/rest/src/main/java/org/eclipse/sensinact/northbound/rest/impl/JsonMapperProvider.java
@@ -14,7 +14,6 @@ package org.eclipse.sensinact.northbound.rest.impl;
 
 import jakarta.ws.rs.ext.ContextResolver;
 import jakarta.ws.rs.ext.Provider;
-import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.cfg.DateTimeFeature;
 import tools.jackson.databind.json.JsonMapper;
 
@@ -22,18 +21,17 @@ import tools.jackson.databind.json.JsonMapper;
  * Provides a suitable ObjectMapper for JSON serialization
  */
 @Provider
-public class ObjectMapperProvider implements ContextResolver<ObjectMapper> {
+public class JsonMapperProvider implements ContextResolver<JsonMapper> {
 
-    private final ObjectMapper mapper;
+    private final JsonMapper mapper;
 
-    public ObjectMapperProvider() {
+    public JsonMapperProvider() {
         this.mapper = JsonMapper.builder()
                 .configure(DateTimeFeature.WRITE_DATES_AS_TIMESTAMPS, false).build();
     }
 
     @Override
-    public ObjectMapper getContext(Class<?> type) {
+    public JsonMapper getContext(Class<?> type) {
         return mapper;
     }
-
 }

--- a/northbound/rest/src/main/java/org/eclipse/sensinact/northbound/rest/impl/RestAccessApplication.java
+++ b/northbound/rest/src/main/java/org/eclipse/sensinact/northbound/rest/impl/RestAccessApplication.java
@@ -60,7 +60,7 @@ public class RestAccessApplication extends Application {
             SensinactSessionProvider.class,
             SensinactSessionManagerProvider.class,
             QueryHandlerProvider.class,
-            ObjectMapperProvider.class,
+            JsonMapperProvider.class,
             JacksonJsonProvider.class,
             JacksonXmlBindJsonProvider.class,
             RestNorthbound.class,

--- a/northbound/rest/src/test/java/org/eclipse/sensinact/northbound/rest/integration/TestUtils.java
+++ b/northbound/rest/src/test/java/org/eclipse/sensinact/northbound/rest/integration/TestUtils.java
@@ -34,10 +34,11 @@ import org.eclipse.sensinact.northbound.query.api.EResultType;
 import org.eclipse.sensinact.northbound.query.dto.result.TypedResponse;
 
 import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 public class TestUtils {
 
-    private final ObjectMapper mapper = new ObjectMapper();
+    public final ObjectMapper mapper = JsonMapper.builder().build();
 
     static final HttpClient client = HttpClient.newHttpClient();
 
@@ -126,8 +127,9 @@ public class TestUtils {
         }
 
         final HttpRequest req = HttpRequest.newBuilder(targetUri).header("Content-Type", "application/json")
-                .method(method, body == null ? BodyPublishers.noBody() :
-                    BodyPublishers.ofString(mapper.writeValueAsString(body))).build();
+                .method(method, body == null ? BodyPublishers.noBody()
+                        : BodyPublishers.ofString(mapper.writeValueAsString(body)))
+                .build();
         final HttpResponse<InputStream> response = client.send(req, (x) -> BodySubscribers.ofInputStream());
         return mapper.createParser(response.body()).readValueAs(resultType);
     }


### PR DESCRIPTION
Provide a JsonMapper instance instead of an ObjectMapper in the REST northbound application.
This allows our JsonMapper to be caught and used by the JacksonJsonProvider, so that query results are correctly serialized.