### PR TITLE
Fix a deserialization bug in Jackson 3

### DIFF
--- a/northbound/query-handler-api/src/main/java/org/eclipse/sensinact/northbound/query/api/AbstractResultDTO.java
+++ b/northbound/query-handler-api/src/main/java/org/eclipse/sensinact/northbound/query/api/AbstractResultDTO.java
@@ -24,6 +24,7 @@ import org.eclipse.sensinact.northbound.query.dto.result.ResultSubscribeDTO;
 import org.eclipse.sensinact.northbound.query.dto.result.ResultUnsubscribeDTO;
 import org.eclipse.sensinact.northbound.query.dto.result.TypedResponse;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
@@ -49,6 +50,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
         @Type(value = ResultResourceNotificationDTO.class, name = "SUBSCRIPTION_NOTIFICATION"),
         @Type(value = ResultUnsubscribeDTO.class, name = "UNSUBSCRIPTION_RESPONSE") })
 @JsonTypeInfo(use = Id.NAME, include = As.PROPERTY, property = "type", visible = true)
+@JsonIgnoreProperties("type")
 public abstract class AbstractResultDTO {
 
     /**

--- a/northbound/query-handler-api/src/test/java/org/eclipse/sensinact/northbound/query/test/SerializationTest.java
+++ b/northbound/query-handler-api/src/test/java/org/eclipse/sensinact/northbound/query/test/SerializationTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.eclipse.sensinact.core.model.ResourceType;
 import org.eclipse.sensinact.gateway.geojson.Coordinates;
@@ -47,6 +48,7 @@ import org.eclipse.sensinact.northbound.query.dto.result.ResponseDescribeResourc
 import org.eclipse.sensinact.northbound.query.dto.result.ResponseDescribeServiceDTO;
 import org.eclipse.sensinact.northbound.query.dto.result.ResponseGetDTO;
 import org.eclipse.sensinact.northbound.query.dto.result.ResponseSetDTO;
+import org.eclipse.sensinact.northbound.query.dto.result.ResponseSnapshotDTO;
 import org.eclipse.sensinact.northbound.query.dto.result.ResultActDTO;
 import org.eclipse.sensinact.northbound.query.dto.result.ResultDescribeProvidersDTO;
 import org.eclipse.sensinact.northbound.query.dto.result.ResultListProvidersDTO;
@@ -626,5 +628,40 @@ public class SerializationTest {
         assertEquals("""
                 [{"provider":{"value":"foo"}},{"provider":{"value":"bar"}}]""", query.filter);
         assertNull(query.uri);
+    }
+
+    @Test
+    void testResponseSnapshot() throws JacksonException {
+        String response = """
+                {
+                    "statusCode": 200,
+                    "type": "SNAPSHOT_RESPONSE",
+                    "providers": {
+                        "foo": {
+                            "name": "foo",
+                            "modelName": "fooModel",
+                            "services": {
+                                "bar": {
+                                    "name": "bar",
+                                    "resources": {
+                                        "foobar": {
+                                            "name": "foobar",
+                                            "timestamp": null,
+                                            "value": null
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                """;
+        ResponseSnapshotDTO resp = mapper.readValue(response, ResponseSnapshotDTO.class);
+
+        assertEquals(EResultType.SNAPSHOT_RESPONSE, resp.type);
+        assertEquals(200, resp.statusCode);
+        assertEquals(Set.of("foo"), resp.providers.keySet());
+        assertEquals("foobar", resp.providers.get("foo").services.get("bar").resources.get("foobar").name);
+        assertNull(resp.uri);
     }
 }


### PR DESCRIPTION
We make use of a custom deserializer for an abstract type which requires a type identity to be passed. A parent type of this can be deserialized using a normal deseriallizer. As a result we mark the type id as visible so the custom deserializer can see it. In Jackson 2 the normal deserializer was lenient about this property and would not complain. In Jackson 3 this has become an error so we must explicitly mark the property as ignored. This ignore only applies at deserialization time (when we need it) as the abstract type id configuration forces it to be serialized.