### PR TITLE
Fix: snapshot Collection values in notifications to prevent Jackson serialization

### DIFF
--- a/core/geo-json/pom.xml
+++ b/core/geo-json/pom.xml
@@ -15,6 +15,10 @@
       <artifactId>osgi.annotation</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+    <dependency>
       <groupId>tools.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>

--- a/core/impl/integration-test.bndrun
+++ b/core/impl/integration-test.bndrun
@@ -56,6 +56,7 @@
 	org.objectweb.asm.util;version='[9.9.1,9.9.2)',\
 	org.objenesis;version='[3.3.0,3.3.1)',\
 	org.opentest4j;version='[1.3.0,1.3.1)',\
+	org.osgi.service.cm;version='[1.6.1,1.6.2)',\
 	org.osgi.service.component;version='[1.5.0,1.5.1)',\
 	org.osgi.service.typedevent;version='[1.0.0,1.0.1)',\
 	org.osgi.test.common;version='[1.3.0,1.3.1)',\

--- a/core/impl/src/main/java/org/eclipse/sensinact/core/notification/impl/AbstractNotificationAccumulatorImpl.java
+++ b/core/impl/src/main/java/org/eclipse/sensinact/core/notification/impl/AbstractNotificationAccumulatorImpl.java
@@ -13,6 +13,8 @@
 package org.eclipse.sensinact.core.notification.impl;
 
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -58,7 +60,18 @@ public abstract class AbstractNotificationAccumulatorImpl implements Notificatio
     protected ResourceDataNotification createResourceDataNotification(String modelPackageUri, String model, String provider, String service,
             String resource, Class<?> type, Object oldValue, Object newValue, Map<String, Object> metadata, Instant timestamp) {
         return new ResourceDataNotification(modelPackageUri, model, provider, service,
-                resource, oldValue, newValue, timestamp, type, metadata);
+                resource, snapshotValue(oldValue), snapshotValue(newValue), timestamp, type, metadata);
+    }
+
+    /**
+     * Returns an immutable snapshot of the value if it is a {@link Collection},
+     * to prevent race conditions when the underlying EMF list is later modified.
+     */
+    private static Object snapshotValue(Object value) {
+        if (value instanceof Collection<?>) {
+            return List.copyOf(new ArrayList<>((Collection<?>) value));
+        }
+        return value;
     }
 
     protected ResourceActionNotification createResourceActionNotification(String modelPackageUri, String model, String provider, String service,

--- a/core/impl/src/main/java/org/eclipse/sensinact/core/notification/impl/AbstractNotificationAccumulatorImpl.java
+++ b/core/impl/src/main/java/org/eclipse/sensinact/core/notification/impl/AbstractNotificationAccumulatorImpl.java
@@ -1,15 +1,15 @@
 /*********************************************************************
-* Copyright (c) 2025 Contributors to the Eclipse Foundation.
-*
-* This program and the accompanying materials are made
-* available under the terms of the Eclipse Public License 2.0
-* which is available at https://www.eclipse.org/legal/epl-2.0/
-*
-* SPDX-License-Identifier: EPL-2.0
-*
-* Contributors:
-*   Kentyou - initial implementation
-**********************************************************************/
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Kentyou - initial implementation
+ **********************************************************************/
 package org.eclipse.sensinact.core.notification.impl;
 
 import java.time.Instant;
@@ -68,8 +68,8 @@ public abstract class AbstractNotificationAccumulatorImpl implements Notificatio
      * to prevent race conditions when the underlying EMF list is later modified.
      */
     private static Object snapshotValue(Object value) {
-        if (value instanceof Collection<?>) {
-            return List.copyOf(new ArrayList<>((Collection<?>) value));
+        if (value instanceof Collection<?> col) {
+            return List.copyOf(new ArrayList<>(col));
         }
         return value;
     }

--- a/core/impl/src/main/java/org/eclipse/sensinact/core/notification/impl/AbstractNotificationAccumulatorImpl.java
+++ b/core/impl/src/main/java/org/eclipse/sensinact/core/notification/impl/AbstractNotificationAccumulatorImpl.java
@@ -13,7 +13,6 @@
 package org.eclipse.sensinact.core.notification.impl;
 
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -69,7 +68,7 @@ public abstract class AbstractNotificationAccumulatorImpl implements Notificatio
      */
     private static Object snapshotValue(Object value) {
         if (value instanceof Collection<?> col) {
-            return List.copyOf(new ArrayList<>(col));
+            return List.copyOf(col);
         }
         return value;
     }

--- a/core/impl/src/test/java/org/eclipse/sensinact/core/notification/impl/NotificationSenderTest.java
+++ b/core/impl/src/test/java/org/eclipse/sensinact/core/notification/impl/NotificationSenderTest.java
@@ -578,6 +578,32 @@ class NotificationSenderTest {
 
             assertTrue(thrown.getMessage().contains("out of temporal order"), "Wrong message: " + thrown.getMessage());
         }
+
+        @Test
+        void testCollectionValueIsSnapshotted() {
+            // Regression test: when newValue/oldValue is a mutable Collection (e.g. an
+            // EMF EDataTypeUniqueEList), the notification must hold an immutable snapshot
+            // taken at call-time. Without the fix, mutating the list before serialization
+            // causes BasicIndexOutOfBoundsException in Jackson.
+            Instant now = Instant.now();
+
+            List<String> mutableNew = new java.util.ArrayList<>(List.of("a", "b"));
+            List<String> mutableOld = new java.util.ArrayList<>(List.of("x"));
+
+            accumulator.resourceValueUpdate(MODEL_PKG, MODEL, PROVIDER, SERVICE, RESOURCE, List.class,
+                    mutableOld, mutableNew, null, now);
+
+            // Simulate concurrent EMF model mutation before the notification is delivered
+            mutableNew.clear();
+            mutableOld.clear();
+
+            accumulator.completeAndSend();
+
+            Mockito.verify(bus).deliver(eq("DATA/" + MODEL + "/" + PROVIDER + "/" + SERVICE + "/" + RESOURCE),
+                    argThat(isValueNotificationWith(PROVIDER, SERVICE, RESOURCE, List.class,
+                            List.of("x"), List.of("a", "b"), null, now)));
+            Mockito.verifyNoMoreInteractions(bus);
+        }
     }
 
     @Nested

--- a/core/impl/src/test/java/org/eclipse/sensinact/core/notification/impl/NotificationSenderTest.java
+++ b/core/impl/src/test/java/org/eclipse/sensinact/core/notification/impl/NotificationSenderTest.java
@@ -1,15 +1,15 @@
 /*********************************************************************
-* Copyright (c) 2025 Contributors to the Eclipse Foundation.
-*
-* This program and the accompanying materials are made
-* available under the terms of the Eclipse Public License 2.0
-* which is available at https://www.eclipse.org/legal/epl-2.0/
-*
-* SPDX-License-Identifier: EPL-2.0
-*
-* Contributors:
-*   Kentyou - initial implementation
-**********************************************************************/
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Kentyou - initial implementation
+ **********************************************************************/
 package org.eclipse.sensinact.core.notification.impl;
 
 import static java.util.Collections.emptyMap;
@@ -581,10 +581,6 @@ class NotificationSenderTest {
 
         @Test
         void testCollectionValueIsSnapshotted() {
-            // Regression test: when newValue/oldValue is a mutable Collection (e.g. an
-            // EMF EDataTypeUniqueEList), the notification must hold an immutable snapshot
-            // taken at call-time. Without the fix, mutating the list before serialization
-            // causes BasicIndexOutOfBoundsException in Jackson.
             Instant now = Instant.now();
 
             List<String> mutableNew = new java.util.ArrayList<>(List.of("a", "b"));
@@ -593,10 +589,12 @@ class NotificationSenderTest {
             accumulator.resourceValueUpdate(MODEL_PKG, MODEL, PROVIDER, SERVICE, RESOURCE, List.class,
                     mutableOld, mutableNew, null, now);
 
-            // Simulate concurrent EMF model mutation before the notification is delivered
+            // Simulate concurrent EMF model mutation after registration
             mutableNew.clear();
             mutableOld.clear();
 
+            // Without snapshotting, the notification would carry the mutated (empty) lists.
+            // With snapshotting, the original values ["a","b"] and ["x"] must be preserved.
             accumulator.completeAndSend();
 
             Mockito.verify(bus).deliver(eq("DATA/" + MODEL + "/" + PROVIDER + "/" + SERVICE + "/" + RESOURCE),


### PR DESCRIPTION
### Problem
When a resource value is a multi-value link (e.g. an EMF `EDataTypeUniqueEList`), the `ResourceDataNotification` was storing a direct reference to the mutable collection. If the underlying EMF model was mutated between the time `resourceValueUpdate` was called and the time Jackson serialized the notification, this caused a `BasicIndexOutOfBoundsException` during serialization.

### Root Cause
In `AbstractNotificationAccumulatorImpl.createResourceDataNotification`, the `oldValue` and `newValue` were passed directly into the `ResourceDataNotification` record without being snapshotted. Any structural modification of the backing list (e.g. by an EMF list's internal management) before the notification was flushed and serialized could corrupt Jackson's iteration.

### Fix
Added a `snapshotValue(Object)` helper that, when the value is a `Collection`, creates an immutable copy. Non-collection values are passed through unchanged.

