### PR TITLE
Handle special case of multi-values when getting resource content

### DIFF
--- a/northbound/session/session-impl/src/main/java/org/eclipse/sensinact/northbound/session/impl/SensiNactSessionImpl.java
+++ b/northbound/session/session-impl/src/main/java/org/eclipse/sensinact/northbound/session/impl/SensiNactSessionImpl.java
@@ -475,13 +475,23 @@ public class SensiNactSessionImpl implements SensiNactSession {
                             break;
 
                         default:
-                            val = sensinactResource.getValue(Object.class, GetLevel.NORMAL).map(tv -> {
-                                // Add the current value
-                                result.valueType = ValueType.UPDATABLE;
-                                result.value = tv.getValue();
-                                result.timestamp = tv.getTimestamp();
-                                return result;
-                            });
+                            if (sensinactResource.isMultiple()) {
+                                val = sensinactResource.getMultiValue(Object.class, GetLevel.NORMAL).map(tv -> {
+                                    // Add the current values
+                                    result.valueType = ValueType.UPDATABLE;
+                                    result.value = tv.getValue();
+                                    result.timestamp = tv.getTimestamp();
+                                    return result;
+                                });
+                            } else {
+                                val = sensinactResource.getValue(Object.class, GetLevel.NORMAL).map(tv -> {
+                                    // Add the current value
+                                    result.valueType = ValueType.UPDATABLE;
+                                    result.value = tv.getValue();
+                                    result.timestamp = tv.getTimestamp();
+                                    return result;
+                                });
+                            }
                             break;
                         }
 

--- a/northbound/session/session-impl/src/main/java/org/eclipse/sensinact/northbound/session/impl/SensiNactSessionImpl.java
+++ b/northbound/session/session-impl/src/main/java/org/eclipse/sensinact/northbound/session/impl/SensiNactSessionImpl.java
@@ -472,27 +472,26 @@ public class SensiNactSessionImpl implements SensiNactSession {
                         case ACTION:
                             result.actMethodArgumentsTypes = sensinactResource.getArguments();
                             val = pf.resolved(result);
-                            break;
+                                break;
 
-                        default:
-                            if (sensinactResource.isMultiple()) {
-                                val = sensinactResource.getMultiValue(Object.class, GetLevel.NORMAL).map(tv -> {
-                                    // Add the current values
-                                    result.valueType = ValueType.UPDATABLE;
-                                    result.value = tv.getValue();
-                                    result.timestamp = tv.getTimestamp();
-                                    return result;
-                                });
-                            } else {
-                                val = sensinactResource.getValue(Object.class, GetLevel.NORMAL).map(tv -> {
+                            default: {
+                                Promise<? extends TimedValue<?>> promise;
+                                if (sensinactResource.isMultiple()) {
+                                    promise = sensinactResource.getMultiValue(Object.class, GetLevel.NORMAL);
+                                } else {
+                                    promise = sensinactResource.getValue(Object.class, GetLevel.NORMAL);
+                                }
+
+                                val = promise.map(tv -> {
                                     // Add the current value
                                     result.valueType = ValueType.UPDATABLE;
                                     result.value = tv.getValue();
                                     result.timestamp = tv.getTimestamp();
                                     return result;
                                 });
+
+                                break;
                             }
-                            break;
                         }
 
                         final Promise<Map<String, Object>> metadata = sensinactResource.getMetadataValues();


### PR DESCRIPTION
Session-based access to resource description was calling `SensinactResource.getValue()`, which always returns only one value.

This PR checks if the value is marked as *many*, so that we get the right resource content (singleton or list)