### PR TITLE
Refactor the Session subscription logic

### DIFF
--- a/northbound/session/session-impl/src/main/java/org/eclipse/sensinact/northbound/session/impl/SensiNactSessionImpl.java
+++ b/northbound/session/session-impl/src/main/java/org/eclipse/sensinact/northbound/session/impl/SensiNactSessionImpl.java
@@ -12,8 +12,6 @@
 **********************************************************************/
 package org.eclipse.sensinact.northbound.session.impl;
 
-import static java.util.stream.Collectors.toList;
-import static org.eclipse.sensinact.core.authorization.PermissionLevel.ACT;
 import static org.eclipse.sensinact.core.authorization.PermissionLevel.DESCRIBE;
 import static org.eclipse.sensinact.core.authorization.PermissionLevel.READ;
 import static org.eclipse.sensinact.core.authorization.PermissionLevel.UPDATE;
@@ -30,9 +28,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.NavigableMap;
 import java.util.Objects;
-import java.util.TreeMap;
 import java.util.UUID;
 import java.util.function.BiFunction;
 import java.util.function.BiPredicate;
@@ -56,11 +52,6 @@ import org.eclipse.sensinact.core.notification.ClientActionListener;
 import org.eclipse.sensinact.core.notification.ClientDataListener;
 import org.eclipse.sensinact.core.notification.ClientLifecycleListener;
 import org.eclipse.sensinact.core.notification.ClientMetadataListener;
-import org.eclipse.sensinact.core.notification.LifecycleNotification;
-import org.eclipse.sensinact.core.notification.ResourceActionNotification;
-import org.eclipse.sensinact.core.notification.ResourceDataNotification;
-import org.eclipse.sensinact.core.notification.ResourceMetaDataNotification;
-import org.eclipse.sensinact.core.notification.ResourceNotification;
 import org.eclipse.sensinact.core.push.DataUpdate;
 import org.eclipse.sensinact.core.push.dto.BulkGenericDto;
 import org.eclipse.sensinact.core.push.dto.GenericDto;
@@ -91,6 +82,7 @@ import org.eclipse.sensinact.northbound.session.SensiNactSessionExpirationListen
 import org.eclipse.sensinact.northbound.session.ServiceDescription;
 import org.eclipse.sensinact.northbound.session.snapshot.ImmutableLinkedProviderSnapshot;
 import org.eclipse.sensinact.northbound.session.snapshot.ImmutableProviderSnapshot;
+import org.osgi.framework.BundleContext;
 import org.osgi.util.promise.Promise;
 import org.osgi.util.promise.PromiseFactory;
 import org.slf4j.Logger;
@@ -106,10 +98,7 @@ public class SensiNactSessionImpl implements SensiNactSession {
 
     private final String sessionId = UUID.randomUUID().toString();
 
-    private final Map<String, List<String>> listenerRegistrations = new HashMap<>();
-
-    private final NavigableMap<String, List<SessionListenerRegistration>> listenersByWildcardTopic = new TreeMap<>();
-    private final Map<String, List<SessionListenerRegistration>> listenersByTopic = new HashMap<>();
+    private final Map<String, SensinactSessionEventManager> listenerRegistrations = new HashMap<>();
 
     private Instant expiry;
 
@@ -125,6 +114,8 @@ public class SensiNactSessionImpl implements SensiNactSession {
      */
     private final SensiNactSessionActivityChecker activityChecker;
 
+    private final BundleContext context;
+
     private final GatewayThread thread;
 
     private final UserInfo user;
@@ -134,12 +125,14 @@ public class SensiNactSessionImpl implements SensiNactSession {
     private final PreAuthorizer preAuthorizer;
 
     public SensiNactSessionImpl(final UserInfo user, final PreAuthorizer preAuthorizer, final Authorizer authorizer,
-            final GatewayThread thread, final Duration expiry, final SensiNactSessionActivityChecker activityChecker) {
+            final GatewayThread thread, final Duration expiry, final SensiNactSessionActivityChecker activityChecker,
+            final BundleContext context) {
         this.user = user;
         this.preAuthorizer = Objects.requireNonNull(preAuthorizer, "No PreAuthorizer given");
         this.authorizer = Objects.requireNonNull(authorizer, "No Authorizer given");
         this.thread = thread;
         this.activityChecker = activityChecker;
+        this.context = context;
         Objects.requireNonNull(expiry, "No session duration given");
         if(expiry.isZero() || expiry.isNegative()) {
             // Infinite session
@@ -152,98 +145,53 @@ public class SensiNactSessionImpl implements SensiNactSession {
     @Override
     public Map<String, List<String>> activeListeners() {
         synchronized (lock) {
-            return new HashMap<>(listenerRegistrations);
+            return listenerRegistrations.entrySet().stream().collect(Collectors.toMap(Entry::getKey, e -> e.getValue().getRequestedTopics()));
         }
     }
 
     @Override
     public String addListener(List<String> topics, ClientDataListener cdl, ClientMetadataListener cml,
             ClientLifecycleListener cll, ClientActionListener cal) {
-        String subscriptionId = UUID.randomUUID().toString();
-
         synchronized (lock) {
-
-            if (cdl != null) {
-                addListenerTopic(topics, "DATA/", new SessionDataListener(subscriptionId, authorizer, cdl));
+            if(expired) {
+                throw new IllegalStateException("The session is expired");
             }
-
-            if (cml != null) {
-                addListenerTopic(topics, "METADATA/", new SessionMetadataListener(subscriptionId, authorizer, cml));
-            }
-
-            if (cll != null) {
-                addListenerTopic(topics, "LIFECYCLE/", new SessionLifecycleListener(subscriptionId, authorizer, cll));
-            }
-
-            if (cal != null) {
-                addListenerTopic(topics, "ACTION/", new SessionActionListener(subscriptionId, authorizer, cal));
-            }
-
-            listenerRegistrations.put(subscriptionId, List.copyOf(topics));
         }
 
-        return subscriptionId;
-    }
+        String subscriptionId = UUID.randomUUID().toString();
 
-    /**
-     * Must be called holding {@link #lock}
-     *
-     * @param topics
-     * @param prefix
-     * @param reg
-     */
-    private void addListenerTopic(List<String> topics, String prefix, SessionListenerRegistration reg) {
-        topics.stream().map(prefix::concat).forEach(s -> {
-            if (s.endsWith("*")) {
-                listenersByWildcardTopic.merge(s.substring(0, s.length() - 1), List.of(reg), this::mergeLists);
+        SensinactSessionEventManager ssem = new SensinactSessionEventManager(context, sessionId,
+                subscriptionId, topics, authorizer, cll, cdl, cml, cal);
+        boolean destroy;
+        synchronized (lock) {
+            if(expired) {
+                destroy = true;
             } else {
-                listenersByTopic.merge(s, List.of(reg), this::mergeLists);
+                try {
+                    listenerRegistrations.put(subscriptionId, ssem);
+                    destroy = false;
+                } catch (Exception e) {
+                    destroy = true;
+                }
             }
-        });
-    }
+        }
 
-    private List<SessionListenerRegistration> mergeLists(List<SessionListenerRegistration> a,
-            List<SessionListenerRegistration> b) {
-        return Stream.of(a, b).flatMap(List::stream).collect(toList());
+        if(destroy) {
+            ssem.destroy();
+            throw new IllegalStateException("The session is expired");
+        }
+        return subscriptionId;
     }
 
     @Override
     public void removeListener(String id) {
+        SensinactSessionEventManager ssem;
         synchronized (lock) {
-            List<String> topics = listenerRegistrations.remove(id);
-
-            if (topics != null) {
-                removeListener(id, "DATA/", topics);
-                removeListener(id, "METADATA/", topics);
-                removeListener(id, "LIFECYCLE/", topics);
-                removeListener(id, "ACTION/", topics);
-            }
+            ssem = listenerRegistrations.remove(id);
         }
-    }
-
-    private void removeListener(String subscriptionId, String prefix, List<String> topics) {
-        topics.stream().map(prefix::concat).forEach(s -> {
-            if (s.endsWith("*")) {
-                listenersByWildcardTopic.computeIfPresent(s.substring(0, s.length() - 1),
-                        (topic, regs) -> this.removeSubscription(subscriptionId, regs));
-            } else {
-                listenersByTopic.computeIfPresent(s, (topic, regs) -> this.removeSubscription(subscriptionId, regs));
-            }
-        });
-    }
-
-    /**
-     * Must be called holding {@link #lock}
-     *
-     * @param subscriptionId
-     * @param regs
-     */
-    private List<SessionListenerRegistration> removeSubscription(String subscriptionId,
-            List<SessionListenerRegistration> regs) {
-        List<SessionListenerRegistration> list = regs.stream().filter(r -> !r.subscriptionId.equals(subscriptionId))
-                .collect(toList());
-
-        return list.isEmpty() ? null : list;
+        if(ssem != null) {
+            ssem.destroy();
+        }
     }
 
     private <I, T> T executeGetCommand(Function<SensinactDigitalTwin, I> caller, Function<I, T> converter) {
@@ -804,28 +752,6 @@ public class SensiNactSessionImpl implements SensiNactSession {
                 ss.getName(), sr.getName());
     }
 
-    public void notify(String topic, ResourceNotification event) {
-        List<SessionListenerRegistration> toNotify;
-        synchronized (lock) {
-            if (!isExpired()) {
-                toNotify = new ArrayList<>();
-                toNotify.addAll(listenersByTopic.getOrDefault(topic, List.of()));
-                for (Entry<String, List<SessionListenerRegistration>> e : listenersByWildcardTopic.headMap(topic, true)
-                        .descendingMap().entrySet()) {
-                    if (topic.startsWith(e.getKey())) {
-                        toNotify.addAll(e.getValue());
-                    } else {
-                        break;
-                    }
-                }
-            } else {
-                toNotify = List.of();
-            }
-        }
-
-        toNotify.forEach(s -> s.notify(topic, event));
-    }
-
     @Override
     public String getSessionId() {
         return sessionId;
@@ -869,16 +795,27 @@ public class SensiNactSessionImpl implements SensiNactSession {
     @Override
     public void expire() {
         final List<SensiNactSessionExpirationListener> listenersToNotify;
+        final List<SensinactSessionEventManager> eventManagersToClose;
         synchronized (lock) {
             if (expired) {
                 // Nothing to do
                 return;
             }
 
-            listenersToNotify = new ArrayList<>(expirationListeners);
+            listenersToNotify = List.copyOf(expirationListeners);
+            eventManagersToClose = List.copyOf(listenerRegistrations.values());
             expired = true;
             LOG.debug("Session {} of user {} expires. {} expiration listeners to notify", sessionId, user.getUserId(),
                     listenersToNotify.size());
+        }
+
+        // Close the registrations outside of the synchronized block
+        for (SensinactSessionEventManager ssem : eventManagersToClose) {
+            try {
+                ssem.destroy();
+            } catch (Exception e) {
+                LOG.error("Exception while closing session event manager", e);
+            }
         }
 
         // Notify listeners outside of the synchronized block
@@ -953,117 +890,6 @@ public class SensiNactSessionImpl implements SensiNactSession {
     private void checkWithException() throws IllegalStateException {
         if (isExpired()) {
             throw new IllegalStateException("Session is expired");
-        }
-    }
-
-    private static abstract class SessionListenerRegistration {
-
-        private final String subscriptionId;
-        protected final Authorizer authorizer;
-
-        public SessionListenerRegistration(String subscriptionId, Authorizer authorizer) {
-            this.subscriptionId = subscriptionId;
-            this.authorizer = authorizer;
-        }
-
-        public abstract void notify(String topic, ResourceNotification notification);
-
-    }
-
-    private static class SessionLifecycleListener extends SessionListenerRegistration {
-
-        private final ClientLifecycleListener listener;
-
-        public SessionLifecycleListener(String subscriptionId, Authorizer authorizer, ClientLifecycleListener listener) {
-            super(subscriptionId, authorizer);
-            this.listener = listener;
-        }
-
-        @Override
-        public void notify(String topic, ResourceNotification notification) {
-
-            LifecycleNotification ln = (LifecycleNotification) notification;
-
-            switch(ln.status()) {
-                case PROVIDER_CREATED:
-                case PROVIDER_DELETED:
-                    if(!authorizer.hasProviderPermission(DESCRIBE, ln.modelPackageUri(), ln.model(), ln.provider())) {
-                        return;
-                    }
-                    break;
-                case RESOURCE_CREATED:
-                case RESOURCE_DELETED:
-                    if(!authorizer.hasResourcePermission(DESCRIBE, ln.modelPackageUri(), ln.model(), ln.provider(), ln.service(), ln.resource())) {
-                        return;
-                    }
-                    break;
-                case SERVICE_CREATED:
-                case SERVICE_DELETED:
-                    if(!authorizer.hasServicePermission(DESCRIBE, ln.modelPackageUri(), ln.model(), ln.provider(), ln.service())) {
-                        return;
-                    }
-                    break;
-                default:
-                    LOG.warn("Unrecognised lifecycle status {}. Denying access to the notification", ln.status());
-                    return;
-            }
-            listener.notify(topic, ln);
-        }
-    }
-
-    private static class SessionMetadataListener extends SessionListenerRegistration {
-
-        private final ClientMetadataListener listener;
-
-        public SessionMetadataListener(String subscriptionId, Authorizer authorizer, ClientMetadataListener listener) {
-            super(subscriptionId, authorizer);
-            this.listener = listener;
-        }
-
-        @Override
-        public void notify(String topic, ResourceNotification notification) {
-            if(!authorizer.hasResourcePermission(READ, notification.modelPackageUri(), notification.model(), notification.provider(), notification.service(), notification.resource())) {
-                return;
-            }
-
-            listener.notify(topic, (ResourceMetaDataNotification) notification);
-        }
-    }
-
-    private static class SessionDataListener extends SessionListenerRegistration {
-
-        private final ClientDataListener listener;
-
-        public SessionDataListener(String subscriptionId, Authorizer authorizer, ClientDataListener listener) {
-            super(subscriptionId, authorizer);
-            this.listener = listener;
-        }
-
-        @Override
-        public void notify(String topic, ResourceNotification notification) {
-            if(!authorizer.hasResourcePermission(READ, notification.modelPackageUri(), notification.model(), notification.provider(), notification.service(), notification.resource())) {
-                return;
-            }
-
-            listener.notify(topic, (ResourceDataNotification) notification);
-        }
-    }
-
-    private static class SessionActionListener extends SessionListenerRegistration {
-
-        private final ClientActionListener listener;
-
-        public SessionActionListener(String subscriptionId, Authorizer authorizer, ClientActionListener listener) {
-            super(subscriptionId, authorizer);
-            this.listener = listener;
-        }
-
-        @Override
-        public void notify(String topic, ResourceNotification notification) {
-            if(!authorizer.hasResourcePermission(ACT, notification.modelPackageUri(), notification.model(), notification.provider(), notification.service(), notification.resource())) {
-                return;
-            }
-            listener.notify(topic, (ResourceActionNotification) notification);
         }
     }
 

--- a/northbound/session/session-impl/src/main/java/org/eclipse/sensinact/northbound/session/impl/SensinactSessionEventManager.java
+++ b/northbound/session/session-impl/src/main/java/org/eclipse/sensinact/northbound/session/impl/SensinactSessionEventManager.java
@@ -1,0 +1,191 @@
+/*********************************************************************
+* Copyright (c) 2022 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   Kentyou - initial implementation
+**********************************************************************/
+package org.eclipse.sensinact.northbound.session.impl;
+
+import static org.eclipse.sensinact.core.authorization.PermissionLevel.ACT;
+import static org.eclipse.sensinact.core.authorization.PermissionLevel.DESCRIBE;
+import static org.eclipse.sensinact.core.authorization.PermissionLevel.READ;
+import static org.osgi.service.typedevent.TypedEventConstants.TYPED_EVENT_TOPICS;
+
+import java.util.ArrayList;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.sensinact.core.authorization.Authorizer;
+import org.eclipse.sensinact.core.notification.ClientActionListener;
+import org.eclipse.sensinact.core.notification.ClientDataListener;
+import org.eclipse.sensinact.core.notification.ClientLifecycleListener;
+import org.eclipse.sensinact.core.notification.ClientMetadataListener;
+import org.eclipse.sensinact.core.notification.LifecycleNotification;
+import org.eclipse.sensinact.core.notification.ResourceActionNotification;
+import org.eclipse.sensinact.core.notification.ResourceDataNotification;
+import org.eclipse.sensinact.core.notification.ResourceMetaDataNotification;
+import org.eclipse.sensinact.core.notification.ResourceNotification;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.typedevent.TypedEventHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SensinactSessionEventManager
+        implements TypedEventHandler<ResourceNotification> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SensinactSessionEventManager.class);
+
+    private final String sessionId;
+    private final String subscriptionId;
+    private final Authorizer authorizer;
+    private final ClientLifecycleListener lifecycleListener;
+    private final ClientDataListener dataListener;
+    private final ClientMetadataListener metadataListener;
+    private final ClientActionListener actionListener;
+
+    private final List<String> requestedTopics;
+    private final List<String> registeredTopics;
+    private final ServiceRegistration<?> registration;
+
+
+    public SensinactSessionEventManager(BundleContext context, String sessionId,
+            String subscriptionId, List<String> topics, Authorizer authorizer,
+            ClientLifecycleListener lifecycleListener, ClientDataListener dataListener,
+            ClientMetadataListener metadataListener, ClientActionListener actionListener) {
+        this.sessionId = sessionId;
+        this.subscriptionId = subscriptionId;
+        this.authorizer = authorizer;
+
+        List<String> prefixes = new ArrayList<>(4);
+
+        if(lifecycleListener == null) {
+            this.lifecycleListener = this::missingAction;
+        } else {
+            prefixes.add("LIFECYCLE/");
+            this.lifecycleListener = lifecycleListener;
+        }
+
+        if(dataListener == null) {
+            this.dataListener = this::missingAction;
+        } else {
+            prefixes.add("DATA/");
+            this.dataListener = dataListener;
+        }
+
+        if(metadataListener == null) {
+            this.metadataListener = this::missingAction;
+        } else {
+            prefixes.add("METADATA/");
+            this.metadataListener = metadataListener;
+        }
+
+        if(actionListener == null) {
+            this.actionListener = this::missingAction;
+        } else {
+            prefixes.add("ACTION/");
+            this.actionListener = actionListener;
+        }
+
+        if(prefixes.isEmpty()) {
+            throw new IllegalArgumentException("At least one listener type must be specified");
+        }
+        requestedTopics = List.copyOf(topics);
+        registeredTopics = prefixes.stream().flatMap(p -> topics.stream().map(p::concat)).toList();
+        registration = context.registerService(TypedEventHandler.class, this, new Hashtable<>(Map.of(TYPED_EVENT_TOPICS, registeredTopics)));
+    }
+
+    public List<String> getRequestedTopics() {
+        return requestedTopics;
+    }
+
+    public List<String> getRegisteredTopics() {
+        return registeredTopics;
+    }
+
+    public void destroy() {
+        try {
+            registration.unregister();
+        } catch (Exception e) {
+            LOG.warn("Unexpected error tidying up session {}", subscriptionId);
+        }
+    }
+
+    @Override
+    public void notify(String topic, ResourceNotification event) {
+        if(event instanceof ResourceDataNotification rdn) {
+            notifyData(topic, rdn);
+        } else if (event instanceof ResourceMetaDataNotification rmn) {
+            notifyMetdata(topic, rmn);
+        } else if (event instanceof LifecycleNotification ln) {
+            notifyLifecycle(topic, ln);
+        } else if (event instanceof ResourceActionNotification ran) {
+            notifyAction(topic, ran);
+        } else {
+            LOG.error("Unknown event with data {}", event);
+        }
+    }
+
+    private void notifyLifecycle(String topic, LifecycleNotification ln) {
+
+        switch(ln.status()) {
+            case PROVIDER_CREATED:
+            case PROVIDER_DELETED:
+                if(!authorizer.hasProviderPermission(DESCRIBE, ln.modelPackageUri(), ln.model(), ln.provider())) {
+                    return;
+                }
+                break;
+            case RESOURCE_CREATED:
+            case RESOURCE_DELETED:
+                if(!authorizer.hasResourcePermission(DESCRIBE, ln.modelPackageUri(), ln.model(), ln.provider(), ln.service(), ln.resource())) {
+                    return;
+                }
+                break;
+            case SERVICE_CREATED:
+            case SERVICE_DELETED:
+                if(!authorizer.hasServicePermission(DESCRIBE, ln.modelPackageUri(), ln.model(), ln.provider(), ln.service())) {
+                    return;
+                }
+                break;
+            default:
+                LOG.warn("Unrecognised lifecycle status {}. Denying access to the notification", ln.status());
+                return;
+        }
+        lifecycleListener.notify(topic, ln);
+    }
+
+    private void notifyData(String topic, ResourceDataNotification notification) {
+        if(!authorizer.hasResourcePermission(READ, notification.modelPackageUri(), notification.model(), notification.provider(), notification.service(), notification.resource())) {
+            return;
+        }
+
+        dataListener.notify(topic, notification);
+    }
+
+    private void notifyMetdata(String topic, ResourceMetaDataNotification notification) {
+        if(!authorizer.hasResourcePermission(READ, notification.modelPackageUri(), notification.model(), notification.provider(), notification.service(), notification.resource())) {
+            return;
+        }
+
+        metadataListener.notify(topic, notification);
+    }
+
+    private void notifyAction(String topic, ResourceActionNotification notification) {
+        if(!authorizer.hasResourcePermission(ACT, notification.modelPackageUri(), notification.model(), notification.provider(), notification.service(), notification.resource())) {
+            return;
+        }
+        actionListener.notify(topic, notification);
+    }
+
+    private void missingAction(String topic, ResourceNotification notification) {
+        LOG.debug("Event received on topic {} for subscription {} in session {}, but there was no listener registered to handle it",
+                topic, subscriptionId, sessionId);
+    }
+}

--- a/northbound/session/session-impl/src/main/java/org/eclipse/sensinact/northbound/session/impl/SessionManager.java
+++ b/northbound/session/session-impl/src/main/java/org/eclipse/sensinact/northbound/session/impl/SessionManager.java
@@ -36,28 +36,25 @@ import java.util.stream.Stream;
 import org.eclipse.sensinact.core.authorization.Authorizer;
 import org.eclipse.sensinact.core.command.GatewayThread;
 import org.eclipse.sensinact.core.metrics.IMetricsGauge;
-import org.eclipse.sensinact.core.notification.ResourceNotification;
 import org.eclipse.sensinact.northbound.security.api.AuthorizationEngine;
 import org.eclipse.sensinact.northbound.security.api.PreAuthorizer;
 import org.eclipse.sensinact.northbound.security.api.UserInfo;
 import org.eclipse.sensinact.northbound.session.SensiNactSession;
 import org.eclipse.sensinact.northbound.session.SensiNactSessionActivityChecker;
 import org.eclipse.sensinact.northbound.session.SensiNactSessionManager;
+import org.osgi.framework.BundleContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.typedevent.TypedEventHandler;
-import org.osgi.service.typedevent.propertytypes.EventTopics;
 import org.osgi.util.promise.PromiseFactory;
 import org.osgi.util.promise.Promises;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @Component(configurationPid = SessionManager.CONFIGURATION_PID, property = IMetricsGauge.NAME + "=sensinact.sessions")
-@EventTopics({ "LIFECYCLE/*", "METADATA/*", "DATA/*", "ACTION/*" })
 public class SessionManager
-        implements SensiNactSessionManager, TypedEventHandler<ResourceNotification>, IMetricsGauge {
+        implements SensiNactSessionManager, IMetricsGauge {
 
     /**
      * Session Manager OSGi Configuration Admin PID
@@ -126,6 +123,11 @@ public class SessionManager
      * Threshold to trigger to the activity check
      */
     private Duration sessionActivityThreshold;
+
+    /**
+     * The bundle context for registering listeners
+     */
+    private BundleContext context;
 
     /**
      * Definition of the component configuration properties
@@ -203,7 +205,8 @@ public class SessionManager
     }
 
     @Activate
-    void start(Config config) {
+    void start(BundleContext context, Config config) {
+        this.context = context;
         final int expiry = config.expiry();
         if (LOG.isDebugEnabled()) {
             LOG.debug("Starting the Session Manager with session lifetime {}s and default authorization policy {}",
@@ -583,7 +586,7 @@ public class SessionManager
         }
 
         final SensiNactSessionImpl session = new SensiNactSessionImpl(user, preAuthorizer, authorizer, thread, expiry,
-                activityChecker);
+                activityChecker, context);
         String sessionId = session.getSessionId();
 
         // Add an expiration listener to clean up session when explicitly expired
@@ -621,28 +624,6 @@ public class SessionManager
      */
     private void handleExplicitSessionExpiration(final SensiNactSession session) {
         removeSession(session.getUserInfo().getUserId(), session.getSessionId(), false);
-    }
-
-    @Override
-    public void notify(String topic, ResourceNotification event) {
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Session Manager received a notification on topic {}", topic);
-        }
-        List<SensiNactSessionImpl> sessions;
-        synchronized (lock) {
-            sessions = new ArrayList<>(this.sessions.values());
-        }
-        for (SensiNactSessionImpl session : sessions) {
-            if (!session.isExpired()) {
-                try {
-                    session.notify(topic, event);
-                } catch (Exception e) {
-                    LOG.error("Error notifying session {} on topic {}", session.getSessionId(), topic);
-                }
-            } else {
-                removeSession(session.getUserInfo().getUserId(), session.getSessionId());
-            }
-        }
     }
 
     @Override


### PR DESCRIPTION
The existing session subscription logic is very low level, and not well encapsulated. Before adding a better snapshot based listener this logic should be refactored to clean up the behaviours. Now each listener will register its own handler, and the typed event implementation can better optimise delivery based on topics.