### PR TITLE
Fail doResourceWork when the resource is missing

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -65,7 +65,7 @@ maven/mavencentral/jakarta.xml.bind/jakarta.xml.bind-api/3.0.1, BSD-3-Clause, ap
 maven/mavencentral/jakarta.xml.bind/jakarta.xml.bind-api/4.0.0, BSD-3-Clause, approved, ee4j.jaxb
 maven/mavencentral/net.java.dev.jna/jna/5.18.1, Apache-2.0 AND LGPL-2.1-or-later, approved, #23404
 maven/mavencentral/org.antlr/antlr4-runtime/4.12.0, BSD-3-Clause, approved, clearlydefined
-maven/mavencentral/org.apache.aries.tx-control/tx-control-provider-jdbc-local/1.0.1, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.apache.aries.tx-control/tx-control-provider-jdbc-local/1.0.1, Apache-2.0 AND MIT, approved, clearlydefined
 maven/mavencentral/org.apache.aries.tx-control/tx-control-service-local/1.0.1, Apache-2.0, approved, #7410
 maven/mavencentral/org.apache.commons/commons-compress/1.28.0, Apache-2.0 AND (Apache-2.0 AND BSD-3-Clause), approved, #22677
 maven/mavencentral/org.apache.commons/commons-csv/1.12.0, Apache-2.0, approved, #16265

--- a/northbound/query-handler-api/src/main/java/org/eclipse/sensinact/northbound/query/dto/result/ErrorResultDTO.java
+++ b/northbound/query-handler-api/src/main/java/org/eclipse/sensinact/northbound/query/dto/result/ErrorResultDTO.java
@@ -12,8 +12,10 @@
 **********************************************************************/
 package org.eclipse.sensinact.northbound.query.dto.result;
 
+import org.eclipse.sensinact.core.authorization.NotPermittedException;
 import org.eclipse.sensinact.northbound.query.api.AbstractResultDTO;
 import org.eclipse.sensinact.northbound.query.api.EResultType;
+import org.eclipse.sensinact.northbound.session.NotFoundException;
 
 /**
  * An error DTO
@@ -29,7 +31,13 @@ public class ErrorResultDTO extends AbstractResultDTO {
      */
     public ErrorResultDTO(final Throwable error) {
         this();
-        this.statusCode = 500;
+        if (error instanceof NotPermittedException) {
+            this.statusCode = 403;
+        } else if (error instanceof NotFoundException) {
+            this.statusCode = 404;
+        } else {
+            this.statusCode = 500;
+        }
         this.error = error != null ? error.getMessage() : "n/a";
     }
 

--- a/northbound/session/session-api/src/main/java/org/eclipse/sensinact/northbound/session/NotFoundException.java
+++ b/northbound/session/session-api/src/main/java/org/eclipse/sensinact/northbound/session/NotFoundException.java
@@ -1,0 +1,21 @@
+/*********************************************************************
+* Copyright (c) 2026 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   Kentyou - initial implementation
+**********************************************************************/
+
+package org.eclipse.sensinact.northbound.session;
+
+public class NotFoundException extends RuntimeException {
+
+    public NotFoundException(String message) {
+        super(message);
+    }
+}

--- a/northbound/session/session-impl/src/main/java/org/eclipse/sensinact/northbound/session/impl/SensiNactSessionImpl.java
+++ b/northbound/session/session-impl/src/main/java/org/eclipse/sensinact/northbound/session/impl/SensiNactSessionImpl.java
@@ -348,7 +348,7 @@ public class SensiNactSessionImpl implements SensiNactSession {
                                 }
                             }
                         }
-                        return pf.resolved(null);
+                        return pf.failed(new IllegalArgumentException("Resource not found"));
                     }
                 } catch (Throwable t) {
                     return pf.failed(t);

--- a/northbound/session/session-impl/src/main/java/org/eclipse/sensinact/northbound/session/impl/SensiNactSessionImpl.java
+++ b/northbound/session/session-impl/src/main/java/org/eclipse/sensinact/northbound/session/impl/SensiNactSessionImpl.java
@@ -73,6 +73,7 @@ import org.eclipse.sensinact.gateway.geojson.GeoJsonObject;
 import org.eclipse.sensinact.northbound.security.api.PreAuthorizer;
 import org.eclipse.sensinact.northbound.security.api.PreAuthorizer.PreAuth;
 import org.eclipse.sensinact.northbound.security.api.UserInfo;
+import org.eclipse.sensinact.northbound.session.NotFoundException;
 import org.eclipse.sensinact.northbound.session.ProviderDescription;
 import org.eclipse.sensinact.northbound.session.ResourceDescription;
 import org.eclipse.sensinact.northbound.session.ResourceShortDescription;
@@ -348,7 +349,7 @@ public class SensiNactSessionImpl implements SensiNactSession {
                                 }
                             }
                         }
-                        return pf.failed(new IllegalArgumentException("Resource not found"));
+                        return pf.failed(new NotFoundException("Resource not found"));
                     }
                 } catch (Throwable t) {
                     return pf.failed(t);
@@ -483,7 +484,7 @@ public class SensiNactSessionImpl implements SensiNactSession {
                                 }
                             }
                         }
-                        return pf.failed(new IllegalArgumentException("Resource not found"));
+                        return pf.failed(new NotFoundException("Resource not found"));
                     }
                 } catch (Throwable t) {
                     return pf.failed(t);

--- a/northbound/session/session-impl/src/main/java/org/eclipse/sensinact/northbound/session/impl/SensiNactSessionImpl.java
+++ b/northbound/session/session-impl/src/main/java/org/eclipse/sensinact/northbound/session/impl/SensiNactSessionImpl.java
@@ -483,7 +483,7 @@ public class SensiNactSessionImpl implements SensiNactSession {
                                 }
                             }
                         }
-                        return pf.resolved(null);
+                        return pf.failed(new IllegalArgumentException("Resource not found"));
                     }
                 } catch (Throwable t) {
                     return pf.failed(t);

--- a/northbound/session/session-impl/src/test/java/org/eclipse/sensinact/northbound/session/integration/SensinactSessionTest.java
+++ b/northbound/session/session-impl/src/test/java/org/eclipse/sensinact/northbound/session/integration/SensinactSessionTest.java
@@ -28,6 +28,7 @@ import org.eclipse.sensinact.core.push.dto.GenericDto;
 import org.eclipse.sensinact.core.twin.SensinactDigitalTwin;
 import org.eclipse.sensinact.core.twin.SensinactProvider;
 import org.eclipse.sensinact.northbound.security.api.UserInfo;
+import org.eclipse.sensinact.northbound.session.NotFoundException;
 import org.eclipse.sensinact.northbound.session.ResourceDescription;
 import org.eclipse.sensinact.northbound.session.SensiNactSession;
 import org.eclipse.sensinact.northbound.session.SensiNactSessionManager;
@@ -127,7 +128,7 @@ public class SensinactSessionTest {
         @Test
         void getNonExistentResource() {
             assertThrows(NotPermittedException.class, () -> anonSession.getResourceValue(PROVIDER, "svc", "nonExistent", String.class));
-            assertThrows(IllegalArgumentException.class, () -> bobSession.getResourceValue(PROVIDER, "svc", "nonExistent", String.class));
+            assertThrows(NotFoundException.class, () -> bobSession.getResourceValue(PROVIDER, "svc", "nonExistent", String.class));
         }
     }
 
@@ -157,7 +158,7 @@ public class SensinactSessionTest {
         @Test
         void describeNonExistentResource() {
             assertThrows(NotPermittedException.class, () -> anonSession.describeResource(PROVIDER, "svc", "nonExistent"));
-            assertThrows(IllegalArgumentException.class, () -> bobSession.describeResource(PROVIDER, "svc", "nonExistent"));
+            assertThrows(NotFoundException.class, () -> bobSession.describeResource(PROVIDER, "svc", "nonExistent"));
         }
     }
 
@@ -190,7 +191,7 @@ public class SensinactSessionTest {
         @Test
         void setNonExistentResource() {
             assertThrows(NotPermittedException.class, () -> anonSession.setResourceValue(PROVIDER, "svc", "nonExistent", "value", Instant.now()));
-            assertThrows(IllegalArgumentException.class, () -> bobSession.setResourceValue(PROVIDER, "svc", "nonExistent", "value", Instant.now()));
+            assertThrows(NotFoundException.class, () -> bobSession.setResourceValue(PROVIDER, "svc", "nonExistent", "value", Instant.now()));
         }
     }
 }

--- a/northbound/session/session-impl/src/test/java/org/eclipse/sensinact/northbound/session/integration/SensinactSessionTest.java
+++ b/northbound/session/session-impl/src/test/java/org/eclipse/sensinact/northbound/session/integration/SensinactSessionTest.java
@@ -123,6 +123,12 @@ public class SensinactSessionTest {
             String location = bobSession.getResourceValue(PROVIDER, "admin", "location", String.class);
             assertNull(location);
         }
+
+        @Test
+        void getNonExistentResource() {
+            assertThrows(NotPermittedException.class, () -> anonSession.getResourceValue(PROVIDER, "svc", "nonExistent", String.class));
+            assertThrows(IllegalArgumentException.class, () -> bobSession.getResourceValue(PROVIDER, "svc", "nonExistent", String.class));
+        }
     }
 
     @Nested
@@ -146,6 +152,12 @@ public class SensinactSessionTest {
             ResourceDescription descr = bobSession.describeResource(PROVIDER, "admin", "location");
             assertNull(descr.value);
             assertNull(descr.timestamp);
+        }
+
+        @Test
+        void describeNonExistentResource() {
+            assertThrows(NotPermittedException.class, () -> anonSession.describeResource(PROVIDER, "svc", "nonExistent"));
+            assertThrows(IllegalArgumentException.class, () -> bobSession.describeResource(PROVIDER, "svc", "nonExistent"));
         }
     }
 
@@ -173,6 +185,12 @@ public class SensinactSessionTest {
             ResourceDescription descr = bobSession.describeResource(PROVIDER, "admin", "friendlyName");
             assertNotEquals("foo", descr.value);
             assertEquals(timestamp, descr.timestamp);
+        }
+
+        @Test
+        void setNonExistentResource() {
+            assertThrows(NotPermittedException.class, () -> anonSession.setResourceValue(PROVIDER, "svc", "nonExistent", "value", Instant.now()));
+            assertThrows(IllegalArgumentException.class, () -> bobSession.setResourceValue(PROVIDER, "svc", "nonExistent", "value", Instant.now()));
         }
     }
 }


### PR DESCRIPTION
Currently, we return null if a work was allowed but not applied on a missing resource. We now fail with an IllegalArgumentException, as expected by the Query Handler
