### PR TITLE
Add session support for filtered subscriptions

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -32,7 +32,7 @@ maven/mavencentral/commons-io/commons-io/2.17.0, Apache-2.0, approved, #16198
 maven/mavencentral/commons-io/commons-io/2.20.0, Apache-2.0, approved, #22562
 maven/mavencentral/commons-logging/commons-logging/1.2, Apache-2.0, approved, CQ10162
 maven/mavencentral/io.dropwizard.metrics/metrics-core/3.2.2, Apache-2.0, approved, CQ13159
-maven/mavencentral/io.dropwizard.metrics/metrics-core/4.2.19, Apache-2.0, approved, clearlydefined
+maven/mavencentral/io.dropwizard.metrics/metrics-core/4.2.19, Apache-2.0, approved, #27707
 maven/mavencentral/io.dropwizard.metrics/metrics-jvm/3.2.2, Apache-2.0, approved, CQ13160
 maven/mavencentral/io.github.dvgaba/easy-rules-core/1.2.1, MIT, approved, #17227
 maven/mavencentral/io.jsonwebtoken/jjwt-api/0.13.0, Apache-2.0, approved, clearlydefined

--- a/filters/resource.selector/src/main/java/org/eclipse/sensinact/filters/resource/selector/api/Selection.java
+++ b/filters/resource.selector/src/main/java/org/eclipse/sensinact/filters/resource/selector/api/Selection.java
@@ -37,6 +37,14 @@ public record Selection(
          */
         boolean negate) {
 
+    /**
+     * Shortcut constructor for an exact selection
+     * @param value
+     */
+    public Selection(String value) {
+        this(value, MatchType.EXACT, false);
+    }
+
     public Selection {
         if(type == null) {
             type = MatchType.EXACT;

--- a/northbound/sensorthings/filter/src/test/java/org/eclipse/sensinact/northbound/filters/sensorthings/RcUtils.java
+++ b/northbound/sensorthings/filter/src/test/java/org/eclipse/sensinact/northbound/filters/sensorthings/RcUtils.java
@@ -12,7 +12,8 @@
 **********************************************************************/
 package org.eclipse.sensinact.northbound.filters.sensorthings;
 
-import java.time.Duration;
+import static org.mockito.Answers.CALLS_REAL_METHODS;
+
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.EnumSet;
@@ -21,15 +22,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import org.eclipse.sensinact.core.command.GetLevel;
 import org.eclipse.sensinact.core.model.ResourceType;
 import org.eclipse.sensinact.core.model.ValueType;
-import org.eclipse.sensinact.core.notification.ClientActionListener;
-import org.eclipse.sensinact.core.notification.ClientDataListener;
-import org.eclipse.sensinact.core.notification.ClientLifecycleListener;
-import org.eclipse.sensinact.core.notification.ClientMetadataListener;
-import org.eclipse.sensinact.core.push.DataUpdate;
-import org.eclipse.sensinact.core.snapshot.ICriterion;
 import org.eclipse.sensinact.core.snapshot.LinkedProviderSnapshot;
 import org.eclipse.sensinact.core.snapshot.ProviderSnapshot;
 import org.eclipse.sensinact.core.snapshot.ResourceSnapshot;
@@ -37,182 +31,16 @@ import org.eclipse.sensinact.core.snapshot.ServiceSnapshot;
 import org.eclipse.sensinact.core.twin.DefaultTimedValue;
 import org.eclipse.sensinact.core.twin.SensinactDigitalTwin.SnapshotOption;
 import org.eclipse.sensinact.core.twin.TimedValue;
-import org.eclipse.sensinact.northbound.security.api.UserInfo;
-import org.eclipse.sensinact.northbound.session.ProviderDescription;
-import org.eclipse.sensinact.northbound.session.ResourceDescription;
-import org.eclipse.sensinact.northbound.session.ResourceShortDescription;
 import org.eclipse.sensinact.northbound.session.SensiNactSession;
-import org.eclipse.sensinact.northbound.session.SensiNactSessionExpirationListener;
-import org.eclipse.sensinact.northbound.session.ServiceDescription;
+import org.mockito.Answers;
+import org.mockito.Mockito;
 
 /**
  * Utility methods for tests
  */
 public class RcUtils {
 
-    private static final class TestSensinactSession implements SensiNactSession {
-
-        @Override
-        public String getSessionId() {
-            // TODO Auto-generated method stub
-            return null;
-        }
-
-        @Override
-        public Instant getExpiry() {
-            // TODO Auto-generated method stub
-            return null;
-        }
-
-        @Override
-        public void extend(Duration duration) {
-            // TODO Auto-generated method stub
-
-        }
-
-        @Override
-        public boolean isExpired() {
-            // TODO Auto-generated method stub
-            return false;
-        }
-
-        @Override
-        public void expire() {
-            // TODO Auto-generated method stub
-
-        }
-
-        @Override
-        public Map<String, List<String>> activeListeners() {
-            // TODO Auto-generated method stub
-            return null;
-        }
-
-        @Override
-        public String addListener(List<String> topics, ClientDataListener cdl, ClientMetadataListener cml,
-                ClientLifecycleListener cll, ClientActionListener cal) {
-            // TODO Auto-generated method stub
-            return null;
-        }
-
-        @Override
-        public void removeListener(String id) {
-            // TODO Auto-generated method stub
-
-        }
-
-        @Override
-        public <T> TimedValue<T> getResourceTimedValue(String provider, String service, String resource, Class<T> clazz,
-                GetLevel getLevel) {
-            // TODO Auto-generated method stub
-            return null;
-        }
-
-        @Override
-        public <T> TimedValue<List<T>> getResourceTimedMultiValue(String provider, String service, String resource,
-                Class<T> clazz, GetLevel getLevel) {
-            // TODO Auto-generated method stub
-            return null;
-        }
-
-        @Override
-        public void setResourceValue(String provider, String service, String resource, Object o) {
-            // TODO Auto-generated method stub
-
-        }
-
-        @Override
-        public void setResourceValue(String provider, String service, String resource, Object o, Instant instant) {
-            // TODO Auto-generated method stub
-
-        }
-
-        @Override
-        public Map<String, Object> getResourceMetadata(String provider, String service, String resource) {
-            // TODO Auto-generated method stub
-            return null;
-        }
-
-        @Override
-        public void setResourceMetadata(String provider, String service, String resource,
-                Map<String, Object> metadata) {
-            // TODO Auto-generated method stub
-
-        }
-
-        @Override
-        public TimedValue<Object> getResourceMetadataValue(String provider, String service, String resource,
-                String metadata) {
-            // TODO Auto-generated method stub
-            return null;
-        }
-
-        @Override
-        public void setResourceMetadata(String provider, String service, String resource, String metadata,
-                Object value) {
-            // TODO Auto-generated method stub
-
-        }
-
-        @Override
-        public Object actOnResource(String provider, String service, String resource, Map<String, Object> parameters) {
-            // TODO Auto-generated method stub
-            return null;
-        }
-
-        @Override
-        public ResourceDescription describeResource(String provider, String service, String resource) {
-            // TODO Auto-generated method stub
-            return null;
-        }
-
-        @Override
-        public ResourceShortDescription describeResourceShort(String provider, String service, String resource) {
-            // TODO Auto-generated method stub
-            return null;
-        }
-
-        @Override
-        public ServiceDescription describeService(String provider, String service) {
-            // TODO Auto-generated method stub
-            return null;
-        }
-
-        @Override
-        public ProviderDescription describeProvider(String provider) {
-            // TODO Auto-generated method stub
-            return null;
-        }
-
-        @Override
-        public ProviderDescription linkProviders(String parent, String child) {
-            // TODO Auto-generated method stub
-            return null;
-        }
-
-        @Override
-        public ProviderDescription unlinkProviders(String parent, String child) {
-            // TODO Auto-generated method stub
-            return null;
-        }
-
-        @Override
-        public List<ProviderDescription> listProviders() {
-            // TODO Auto-generated method stub
-            return null;
-        }
-
-        @Override
-        public List<ProviderSnapshot> filteredSnapshot(ICriterion filter) {
-            // TODO Auto-generated method stub
-            return null;
-        }
-
-        @Override
-        public List<ProviderSnapshot> filteredSnapshot(ICriterion filter, EnumSet<SnapshotOption> snapshotOptions) {
-            // TODO Auto-generated method stub
-            return null;
-        }
+    private static abstract class TestSensinactSession implements SensiNactSession {
 
         private Map<String, ProviderSnapshot> map = new HashMap<String, ProviderSnapshot>();
 
@@ -224,42 +52,6 @@ public class RcUtils {
         public ProviderSnapshot providerSnapshot(String provider, EnumSet<SnapshotOption> snapshotOptions) {
 
             return map.get(provider);
-        }
-
-        @Override
-        public ServiceSnapshot serviceSnapshot(String provider, String service) {
-            // TODO Auto-generated method stub
-            return null;
-        }
-
-        @Override
-        public ResourceSnapshot resourceSnapshot(String provider, String service, String resource) {
-            // TODO Auto-generated method stub
-            return null;
-        }
-
-        @Override
-        public UserInfo getUserInfo() {
-            // TODO Auto-generated method stub
-            return null;
-        }
-
-        @Override
-        public void addExpirationListener(SensiNactSessionExpirationListener listener) {
-            // TODO Auto-generated method stub
-
-        }
-
-        @Override
-        public void removeExpirationListener(SensiNactSessionExpirationListener listener) {
-            // TODO Auto-generated method stub
-
-        }
-
-        @Override
-        public ProviderDescription setProvider(String provider, Map<String, Object> rcValues, DataUpdate push) {
-            // TODO Auto-generated method stub
-            return null;
         }
 
     }
@@ -369,7 +161,8 @@ public class RcUtils {
 
     static TestSensinactSession getSession() {
         if (session == null) {
-            session = new TestSensinactSession();
+            session = Mockito.mock(TestSensinactSession.class);
+            Mockito.lenient().when(session.providerSnapshot(Mockito.anyString(), Mockito.any())).then(CALLS_REAL_METHODS);
         }
         return session;
     }

--- a/northbound/session/session-api/src/main/java/org/eclipse/sensinact/northbound/session/SensiNactSession.java
+++ b/northbound/session/session-api/src/main/java/org/eclipse/sensinact/northbound/session/SensiNactSession.java
@@ -17,6 +17,7 @@ import java.time.Instant;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 
 import org.eclipse.sensinact.core.command.GetLevel;
 import org.eclipse.sensinact.core.notification.ClientActionListener;
@@ -24,7 +25,6 @@ import org.eclipse.sensinact.core.notification.ClientDataListener;
 import org.eclipse.sensinact.core.notification.ClientLifecycleListener;
 import org.eclipse.sensinact.core.notification.ClientMetadataListener;
 import org.eclipse.sensinact.core.push.DataUpdate;
-import org.eclipse.sensinact.core.push.dto.GenericDto;
 import org.eclipse.sensinact.core.snapshot.ICriterion;
 import org.eclipse.sensinact.core.snapshot.ProviderSnapshot;
 import org.eclipse.sensinact.core.snapshot.ResourceSnapshot;
@@ -95,12 +95,34 @@ public interface SensiNactSession {
     String addListener(List<String> topics, ClientDataListener cdl, ClientMetadataListener cml,
             ClientLifecycleListener cll, ClientActionListener cal);
 
+
     /**
      * Remove a registered listener
      *
      * @param id the registration identifier
      */
     void removeListener(String id);
+
+    /**
+     * Create a filtered subscription. On first connection the consumer will be called with
+     * an event containing the full set of initial matches. The consumer will then be called
+     * each time that there is a relevant update to the set of subscribed data.
+     *
+     * @param filter The filter to determine what data should be listened to
+     * @param updateListener  a listener which will be notified of updates in the set of filtered data
+     * @return a new registration identifier
+     */
+    String subscribe(ICriterion filter, Consumer<SnapshotUpdate> updateListener);
+
+    /**
+     * Remove a registered subscription
+     * Note that this method is an alias for {@link #removeListener(String)}
+     *
+     * @param id the registration identifier
+     */
+    default void unsubscribe(String id) {
+        removeListener(id);
+    }
 
     /**
      * Get the value of a resource with with a {@link GetLevel#NORMAL} operation.

--- a/northbound/session/session-api/src/main/java/org/eclipse/sensinact/northbound/session/SnapshotUpdate.java
+++ b/northbound/session/session-api/src/main/java/org/eclipse/sensinact/northbound/session/SnapshotUpdate.java
@@ -1,0 +1,39 @@
+/*********************************************************************
+* Copyright (c) 2026 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   Kentyou - initial implementation
+**********************************************************************/
+package org.eclipse.sensinact.northbound.session;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.sensinact.core.snapshot.ProviderSnapshot;
+
+public record SnapshotUpdate(
+        /**
+         * Providers that were not previously selected by
+         * the snapshot, but are now as the result of a
+         * provider being created or updated
+         */
+        Map<String, ProviderSnapshot> arriving,
+        /**
+         * Providers that were selected before, have been
+         * updated, and still match the selection filter
+         */
+        Map<String, ProviderSnapshot> modified,
+        /**
+         * Providers that were previously selected by the
+         * snapshot, but are no longer selected because
+         * of the provider being update or deleted
+         */
+        Set<String> departing) {
+
+}

--- a/northbound/session/session-impl/integration-test.bndrun
+++ b/northbound/session/session-impl/integration-test.bndrun
@@ -2,7 +2,8 @@
 
 -runrequires: \
 	bnd.identity;id='${project.groupId}.${project.artifactId}-tests',\
-	bnd.identity;id='ch.qos.logback.classic'
+	bnd.identity;id='ch.qos.logback.classic',\
+	bnd.identity;id='org.eclipse.sensinact.gateway.filters.resource.selector.impl'
 -resolve.effective: active
 
 -runee: JavaSE-25
@@ -21,6 +22,7 @@
 	ch.qos.logback.classic;version='[1.5.31,1.5.32)',\
 	ch.qos.logback.core;version='[1.5.31,1.5.32)',\
 	com.fasterxml.jackson.core.jackson-annotations;version='[2.21.0,2.21.1)',\
+	com.fasterxml.jackson.core.jackson-core;version='[2.12.7,2.12.8)',\
 	io.dropwizard.metrics.core;version='[4.2.19,4.2.20)',\
 	junit-jupiter-api;version='[5.14.3,5.14.4)',\
 	junit-jupiter-engine;version='[5.14.3,5.14.4)',\
@@ -42,6 +44,10 @@
 	org.eclipse.sensinact.gateway.core.geo-json;version='[0.0.2,0.0.3)',\
 	org.eclipse.sensinact.gateway.core.impl;version='[0.0.2,0.0.3)',\
 	org.eclipse.sensinact.gateway.core.models.provider;version='[0.0.2,0.0.3)',\
+	org.eclipse.sensinact.gateway.filters.esri.geometry;version='[0.0.2,0.0.3)',\
+	org.eclipse.sensinact.gateway.filters.filters.core;version='[0.0.2,0.0.3)',\
+	org.eclipse.sensinact.gateway.filters.resource.selector;version='[0.0.2,0.0.3)',\
+	org.eclipse.sensinact.gateway.filters.resource.selector.impl;version='[0.0.2,0.0.3)',\
 	org.eclipse.sensinact.gateway.northbound.security.security-api;version='[0.0.2,0.0.3)',\
 	org.eclipse.sensinact.gateway.northbound.session.session-api;version='[0.0.2,0.0.3)',\
 	org.eclipse.sensinact.gateway.northbound.session.session-impl;version='[0.0.2,0.0.3)',\

--- a/northbound/session/session-impl/pom.xml
+++ b/northbound/session/session-impl/pom.xml
@@ -67,6 +67,12 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.eclipse.sensinact.gateway.filters</groupId>
+      <artifactId>resource.selector.impl</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/northbound/session/session-impl/src/main/java/org/eclipse/sensinact/northbound/session/impl/AbstractSensinactSessionEventManager.java
+++ b/northbound/session/session-impl/src/main/java/org/eclipse/sensinact/northbound/session/impl/AbstractSensinactSessionEventManager.java
@@ -1,0 +1,108 @@
+/*********************************************************************
+* Copyright (c) 2022 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   Kentyou - initial implementation
+**********************************************************************/
+package org.eclipse.sensinact.northbound.session.impl;
+
+import static org.osgi.service.typedevent.TypedEventConstants.TYPED_EVENT_TOPICS;
+
+import java.util.Hashtable;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.eclipse.sensinact.core.authorization.Authorizer;
+import org.eclipse.sensinact.core.notification.LifecycleNotification;
+import org.eclipse.sensinact.core.notification.ResourceActionNotification;
+import org.eclipse.sensinact.core.notification.ResourceDataNotification;
+import org.eclipse.sensinact.core.notification.ResourceMetaDataNotification;
+import org.eclipse.sensinact.core.notification.ResourceNotification;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.typedevent.TypedEventHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class AbstractSensinactSessionEventManager
+        implements TypedEventHandler<ResourceNotification> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractSensinactSessionEventManager.class);
+
+    protected final String sessionId;
+    protected final String subscriptionId;
+    protected final Authorizer authorizer;
+
+    private final List<String> requestedTopics;
+    private AtomicReference<ServiceRegistration<?>> registration = new AtomicReference<ServiceRegistration<?>>();
+
+
+    public AbstractSensinactSessionEventManager(String sessionId,
+            String subscriptionId, List<String> topics, Authorizer authorizer) {
+        this.sessionId = sessionId;
+        this.subscriptionId = subscriptionId;
+        this.authorizer = authorizer;
+        requestedTopics = List.copyOf(topics);
+    }
+
+    /**
+     * To be called in the sub-class constructor once registered topics are available
+     * @param context
+     */
+    protected void register(BundleContext context) {
+        List<String> registeredTopics = getRegisteredTopics();
+        if(registeredTopics.isEmpty()) {
+            throw new IllegalArgumentException("No topics are registered");
+        }
+        registration.set(
+                context.registerService(TypedEventHandler.class, this,
+                        new Hashtable<>(Map.of(TYPED_EVENT_TOPICS, registeredTopics))));
+    }
+
+    public List<String> getRequestedTopics() {
+        return requestedTopics;
+    }
+
+    public abstract List<String> getRegisteredTopics();
+
+    public void destroy() {
+        try {
+            ServiceRegistration<?> reg = registration.getAndSet(null);
+            if(reg != null) {
+                reg.unregister();
+            }
+        } catch (Exception e) {
+            LOG.warn("Unexpected error tidying up session {}", subscriptionId);
+        }
+    }
+
+    @Override
+    public void notify(String topic, ResourceNotification event) {
+        if(event instanceof ResourceDataNotification rdn) {
+            notifyData(topic, rdn);
+        } else if (event instanceof ResourceMetaDataNotification rmn) {
+            notifyMetdata(topic, rmn);
+        } else if (event instanceof LifecycleNotification ln) {
+            notifyLifecycle(topic, ln);
+        } else if (event instanceof ResourceActionNotification ran) {
+            notifyAction(topic, ran);
+        } else {
+            LOG.error("Unknown event with data {}", event);
+        }
+    }
+
+    protected abstract void notifyLifecycle(String topic, LifecycleNotification ln);
+
+    protected abstract void notifyData(String topic, ResourceDataNotification notification);
+
+    protected abstract void notifyMetdata(String topic, ResourceMetaDataNotification notification);
+
+    protected abstract void notifyAction(String topic, ResourceActionNotification notification);
+}

--- a/northbound/session/session-impl/src/main/java/org/eclipse/sensinact/northbound/session/impl/SensiNactSessionImpl.java
+++ b/northbound/session/session-impl/src/main/java/org/eclipse/sensinact/northbound/session/impl/SensiNactSessionImpl.java
@@ -32,6 +32,7 @@ import java.util.Objects;
 import java.util.UUID;
 import java.util.function.BiFunction;
 import java.util.function.BiPredicate;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -80,6 +81,7 @@ import org.eclipse.sensinact.northbound.session.SensiNactSession;
 import org.eclipse.sensinact.northbound.session.SensiNactSessionActivityChecker;
 import org.eclipse.sensinact.northbound.session.SensiNactSessionExpirationListener;
 import org.eclipse.sensinact.northbound.session.ServiceDescription;
+import org.eclipse.sensinact.northbound.session.SnapshotUpdate;
 import org.eclipse.sensinact.northbound.session.snapshot.ImmutableLinkedProviderSnapshot;
 import org.eclipse.sensinact.northbound.session.snapshot.ImmutableProviderSnapshot;
 import org.osgi.framework.BundleContext;
@@ -98,7 +100,7 @@ public class SensiNactSessionImpl implements SensiNactSession {
 
     private final String sessionId = UUID.randomUUID().toString();
 
-    private final Map<String, SensinactSessionEventManager> listenerRegistrations = new HashMap<>();
+    private final Map<String, AbstractSensinactSessionEventManager> listenerRegistrations = new HashMap<>();
 
     private Instant expiry;
 
@@ -152,6 +154,11 @@ public class SensiNactSessionImpl implements SensiNactSession {
     @Override
     public String addListener(List<String> topics, ClientDataListener cdl, ClientMetadataListener cml,
             ClientLifecycleListener cll, ClientActionListener cal) {
+        return doAddListener(subId -> new SensinactSessionEventListener(context, sessionId,
+                subId, topics, authorizer, cll, cdl, cml, cal));
+    }
+
+    private String doAddListener(Function<String, AbstractSensinactSessionEventManager> creator) {
         synchronized (lock) {
             if(expired) {
                 throw new IllegalStateException("The session is expired");
@@ -160,8 +167,7 @@ public class SensiNactSessionImpl implements SensiNactSession {
 
         String subscriptionId = UUID.randomUUID().toString();
 
-        SensinactSessionEventManager ssem = new SensinactSessionEventManager(context, sessionId,
-                subscriptionId, topics, authorizer, cll, cdl, cml, cal);
+        AbstractSensinactSessionEventManager ssem = creator.apply(subscriptionId);
         boolean destroy;
         synchronized (lock) {
             if(expired) {
@@ -185,7 +191,7 @@ public class SensiNactSessionImpl implements SensiNactSession {
 
     @Override
     public void removeListener(String id) {
-        SensinactSessionEventManager ssem;
+        AbstractSensinactSessionEventManager ssem;
         synchronized (lock) {
             ssem = listenerRegistrations.remove(id);
         }
@@ -194,13 +200,25 @@ public class SensiNactSessionImpl implements SensiNactSession {
         }
     }
 
+    @Override
+    public String subscribe(ICriterion filter, Consumer<SnapshotUpdate> updateListener) {
+        return doAddListener(subId -> new SensinactSessionSnapshotListener(context, sessionId,
+                subId, List.of(), authorizer, filter, updateListener,
+                () -> asyncFilteredSnapshot(filter, EnumSet.of(SnapshotOption.INCLUDE_LINKED_PROVIDERS_FULL))));
+    }
+
     private <I, T> T executeGetCommand(Function<SensinactDigitalTwin, I> caller, Function<I, T> converter) {
         return executeGetCommand(caller, converter, null);
     }
 
     private <I, T> T executeGetCommand(Function<SensinactDigitalTwin, I> caller, Function<I, T> converter,
             T defaultValue) {
-        return safeExecute(new AbstractTwinCommand<T>() {
+        return safeExecute(getCommand(caller, converter, defaultValue));
+    }
+
+    private <I, T> AbstractTwinCommand<T> getCommand(Function<SensinactDigitalTwin, I> caller, Function<I, T> converter,
+            T defaultValue) {
+        return new AbstractTwinCommand<T>() {
             @Override
             protected Promise<T> call(SensinactDigitalTwin model, PromiseFactory pf) {
                 try {
@@ -216,7 +234,7 @@ public class SensiNactSessionImpl implements SensiNactSession {
                     return pf.failed(e);
                 }
             }
-        });
+        };
     }
 
     private <T> T safeExecute(AbstractTwinCommand<T> command) {
@@ -607,31 +625,39 @@ public class SensiNactSessionImpl implements SensiNactSession {
 
     @Override
     public List<ProviderSnapshot> filteredSnapshot(ICriterion filter, EnumSet<SnapshotOption> snapshotOptions) {
+        return safeGetValue(asyncFilteredSnapshot(filter, snapshotOptions));
+    }
+
+    private Promise<List<ProviderSnapshot>> asyncFilteredSnapshot(ICriterion filter, EnumSet<SnapshotOption> snapshotOptions) {
+        // We check validity here as we don't use the blocking safeExecute
+        checkWithException();
         Predicate<ServiceSnapshot> service = this::authorizeService;
         Predicate<ResourceSnapshot> resource = this::authorizeResource;
 
-        Stream<ProviderSnapshot> snapshots;
+        Promise<Stream<ProviderSnapshot>> snapshots;
         if (filter == null) {
-            snapshots = executeGetCommand((m) -> m.filteredSnapshot(null, ps -> authorizeProvider(ps, false),
-                    service, resource, snapshotOptions), Function.identity()).stream();
+            snapshots = thread.execute(getCommand((m) -> m.filteredSnapshot(null, ps -> authorizeProvider(ps, false),
+                    service, resource, snapshotOptions), List::stream, null));
         } else {
             BiPredicate<ProviderSnapshot, GeoJsonObject> location = filter.getLocationFilter();
             Predicate<ProviderSnapshot> provider = ps -> authorizeProvider(ps, location != null);
             Predicate<ProviderSnapshot> pf = filter.getProviderFilter();
             Predicate<ServiceSnapshot> sf = filter.getServiceFilter();
             Predicate<ResourceSnapshot> rf = filter.getResourceFilter();
-            snapshots = executeGetCommand((m) -> m.filteredSnapshot(location, pf == null ? provider : provider.and(pf),
-                    sf == null ? service : service.and(sf), rf == null ? resource : resource.and(rf)), Function.identity()).stream();
+            snapshots = thread.execute(getCommand((m) -> m.filteredSnapshot(location, pf == null ? provider : provider.and(pf),
+                    sf == null ? service : service.and(sf), rf == null ? resource : resource.and(rf)), List::stream, null));
             final ResourceValueFilter rcFilter = filter.getResourceValueFilter();
             if (rcFilter != null) {
-                snapshots = snapshots.filter(p -> rcFilter.test(p, p.getServices().stream()
-                        .flatMap(s -> s.getResources().stream()).toList()));
+                snapshots = snapshots
+                        .map(providerStream -> providerStream
+                                .filter(p -> rcFilter.test(p, p.getServices().stream()
+                                        .flatMap(s -> s.getResources().stream()).toList())));
             }
         }
 
-        return snapshots
-            .map(this::safeProviderSnapshot)
-            .toList();
+        return snapshots.map(providerStream -> providerStream
+                .map(this::safeProviderSnapshot)
+                .toList());
     }
 
     /**
@@ -795,7 +821,7 @@ public class SensiNactSessionImpl implements SensiNactSession {
     @Override
     public void expire() {
         final List<SensiNactSessionExpirationListener> listenersToNotify;
-        final List<SensinactSessionEventManager> eventManagersToClose;
+        final List<AbstractSensinactSessionEventManager> eventManagersToClose;
         synchronized (lock) {
             if (expired) {
                 // Nothing to do
@@ -810,7 +836,7 @@ public class SensiNactSessionImpl implements SensiNactSession {
         }
 
         // Close the registrations outside of the synchronized block
-        for (SensinactSessionEventManager ssem : eventManagersToClose) {
+        for (AbstractSensinactSessionEventManager ssem : eventManagersToClose) {
             try {
                 ssem.destroy();
             } catch (Exception e) {

--- a/northbound/session/session-impl/src/main/java/org/eclipse/sensinact/northbound/session/impl/SensinactSessionEventListener.java
+++ b/northbound/session/session-impl/src/main/java/org/eclipse/sensinact/northbound/session/impl/SensinactSessionEventListener.java
@@ -15,12 +15,9 @@ package org.eclipse.sensinact.northbound.session.impl;
 import static org.eclipse.sensinact.core.authorization.PermissionLevel.ACT;
 import static org.eclipse.sensinact.core.authorization.PermissionLevel.DESCRIBE;
 import static org.eclipse.sensinact.core.authorization.PermissionLevel.READ;
-import static org.osgi.service.typedevent.TypedEventConstants.TYPED_EVENT_TOPICS;
 
 import java.util.ArrayList;
-import java.util.Hashtable;
 import java.util.List;
-import java.util.Map;
 
 import org.eclipse.sensinact.core.authorization.Authorizer;
 import org.eclipse.sensinact.core.notification.ClientActionListener;
@@ -33,36 +30,28 @@ import org.eclipse.sensinact.core.notification.ResourceDataNotification;
 import org.eclipse.sensinact.core.notification.ResourceMetaDataNotification;
 import org.eclipse.sensinact.core.notification.ResourceNotification;
 import org.osgi.framework.BundleContext;
-import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.typedevent.TypedEventHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class SensinactSessionEventManager
+public class SensinactSessionEventListener extends AbstractSensinactSessionEventManager
         implements TypedEventHandler<ResourceNotification> {
 
-    private static final Logger LOG = LoggerFactory.getLogger(SensinactSessionEventManager.class);
+    private static final Logger LOG = LoggerFactory.getLogger(SensinactSessionEventListener.class);
 
-    private final String sessionId;
-    private final String subscriptionId;
-    private final Authorizer authorizer;
     private final ClientLifecycleListener lifecycleListener;
     private final ClientDataListener dataListener;
     private final ClientMetadataListener metadataListener;
     private final ClientActionListener actionListener;
 
-    private final List<String> requestedTopics;
     private final List<String> registeredTopics;
-    private final ServiceRegistration<?> registration;
 
 
-    public SensinactSessionEventManager(BundleContext context, String sessionId,
+    public SensinactSessionEventListener(BundleContext context, String sessionId,
             String subscriptionId, List<String> topics, Authorizer authorizer,
             ClientLifecycleListener lifecycleListener, ClientDataListener dataListener,
             ClientMetadataListener metadataListener, ClientActionListener actionListener) {
-        this.sessionId = sessionId;
-        this.subscriptionId = subscriptionId;
-        this.authorizer = authorizer;
+        super(sessionId, subscriptionId, topics, authorizer);
 
         List<String> prefixes = new ArrayList<>(4);
 
@@ -97,43 +86,15 @@ public class SensinactSessionEventManager
         if(prefixes.isEmpty()) {
             throw new IllegalArgumentException("At least one listener type must be specified");
         }
-        requestedTopics = List.copyOf(topics);
         registeredTopics = prefixes.stream().flatMap(p -> topics.stream().map(p::concat)).toList();
-        registration = context.registerService(TypedEventHandler.class, this, new Hashtable<>(Map.of(TYPED_EVENT_TOPICS, registeredTopics)));
-    }
-
-    public List<String> getRequestedTopics() {
-        return requestedTopics;
+        register(context);
     }
 
     public List<String> getRegisteredTopics() {
         return registeredTopics;
     }
 
-    public void destroy() {
-        try {
-            registration.unregister();
-        } catch (Exception e) {
-            LOG.warn("Unexpected error tidying up session {}", subscriptionId);
-        }
-    }
-
-    @Override
-    public void notify(String topic, ResourceNotification event) {
-        if(event instanceof ResourceDataNotification rdn) {
-            notifyData(topic, rdn);
-        } else if (event instanceof ResourceMetaDataNotification rmn) {
-            notifyMetdata(topic, rmn);
-        } else if (event instanceof LifecycleNotification ln) {
-            notifyLifecycle(topic, ln);
-        } else if (event instanceof ResourceActionNotification ran) {
-            notifyAction(topic, ran);
-        } else {
-            LOG.error("Unknown event with data {}", event);
-        }
-    }
-
-    private void notifyLifecycle(String topic, LifecycleNotification ln) {
+    protected void notifyLifecycle(String topic, LifecycleNotification ln) {
 
         switch(ln.status()) {
             case PROVIDER_CREATED:
@@ -161,15 +122,14 @@ public class SensinactSessionEventManager
         lifecycleListener.notify(topic, ln);
     }
 
-    private void notifyData(String topic, ResourceDataNotification notification) {
+    protected void notifyData(String topic, ResourceDataNotification notification) {
         if(!authorizer.hasResourcePermission(READ, notification.modelPackageUri(), notification.model(), notification.provider(), notification.service(), notification.resource())) {
             return;
         }
-
         dataListener.notify(topic, notification);
     }
 
-    private void notifyMetdata(String topic, ResourceMetaDataNotification notification) {
+    protected void notifyMetdata(String topic, ResourceMetaDataNotification notification) {
         if(!authorizer.hasResourcePermission(READ, notification.modelPackageUri(), notification.model(), notification.provider(), notification.service(), notification.resource())) {
             return;
         }
@@ -177,7 +137,7 @@ public class SensinactSessionEventManager
         metadataListener.notify(topic, notification);
     }
 
-    private void notifyAction(String topic, ResourceActionNotification notification) {
+    protected void notifyAction(String topic, ResourceActionNotification notification) {
         if(!authorizer.hasResourcePermission(ACT, notification.modelPackageUri(), notification.model(), notification.provider(), notification.service(), notification.resource())) {
             return;
         }

--- a/northbound/session/session-impl/src/main/java/org/eclipse/sensinact/northbound/session/impl/SensinactSessionSnapshotListener.java
+++ b/northbound/session/session-impl/src/main/java/org/eclipse/sensinact/northbound/session/impl/SensinactSessionSnapshotListener.java
@@ -1,0 +1,448 @@
+/*********************************************************************
+* Copyright (c) 2022 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   Kentyou - initial implementation
+**********************************************************************/
+package org.eclipse.sensinact.northbound.session.impl;
+
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toUnmodifiableMap;
+import static java.util.stream.Collectors.toUnmodifiableSet;
+import static org.eclipse.sensinact.core.authorization.PermissionLevel.DESCRIBE;
+import static org.eclipse.sensinact.core.authorization.PermissionLevel.READ;
+
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.Semaphore;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.eclipse.sensinact.core.authorization.Authorizer;
+import org.eclipse.sensinact.core.notification.LifecycleNotification;
+import org.eclipse.sensinact.core.notification.LifecycleNotification.Status;
+import org.eclipse.sensinact.core.notification.ResourceActionNotification;
+import org.eclipse.sensinact.core.notification.ResourceDataNotification;
+import org.eclipse.sensinact.core.notification.ResourceMetaDataNotification;
+import org.eclipse.sensinact.core.notification.ResourceNotification;
+import org.eclipse.sensinact.core.snapshot.ICriterion;
+import org.eclipse.sensinact.core.snapshot.LinkedProviderSnapshot;
+import org.eclipse.sensinact.core.snapshot.ProviderSnapshot;
+import org.eclipse.sensinact.core.snapshot.ResourceSnapshot;
+import org.eclipse.sensinact.core.snapshot.ServiceSnapshot;
+import org.eclipse.sensinact.core.twin.DefaultTimedValue;
+import org.eclipse.sensinact.core.twin.TimedValue;
+import org.eclipse.sensinact.northbound.session.SnapshotUpdate;
+import org.eclipse.sensinact.northbound.session.snapshot.ImmutableProviderSnapshot;
+import org.eclipse.sensinact.northbound.session.snapshot.ImmutableResourceSnapshot;
+import org.eclipse.sensinact.northbound.session.snapshot.ImmutableServiceSnapshot;
+import org.osgi.framework.BundleContext;
+import org.osgi.service.typedevent.TypedEventHandler;
+import org.osgi.util.promise.Promise;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SensinactSessionSnapshotListener extends AbstractSensinactSessionEventManager
+        implements TypedEventHandler<ResourceNotification> {
+
+    private static enum State { OUTDATED, UP_TO_DATE, SKIP }
+
+    private static final Logger LOG = LoggerFactory.getLogger(SensinactSessionSnapshotListener.class);
+
+    private final ICriterion filter;
+    private final Consumer<SnapshotUpdate> snapshotUpdate;
+    private final Supplier<Promise<List<ProviderSnapshot>>> updateRequest;
+
+    private final List<String> registeredTopics;
+
+    private final Object lock = new Object();
+    private Deque<Function<Map<String, ProviderSnapshot>, State>> pendingChecks = new LinkedList<>();
+    private boolean firstUpdateSent;
+    private boolean updateInProgress;
+    private Deque<Map<String, ProviderSnapshot>> snapshots = new LinkedList<Map<String,ProviderSnapshot>>();
+    /**
+     * Mutual exclusion when delivering updates
+     */
+    private final Semaphore notificationSemaphore = new Semaphore(1);
+
+
+    public SensinactSessionSnapshotListener(BundleContext context, String sessionId,
+            String subscriptionId, List<String> topics, Authorizer authorizer,
+            ICriterion filter, Consumer<SnapshotUpdate> snapshotUpdate,
+            Supplier<Promise<List<ProviderSnapshot>>> updateRequest) {
+        super(sessionId, subscriptionId, topics, authorizer);
+
+        this.filter = filter;
+        this.snapshotUpdate = snapshotUpdate;
+        this.updateRequest = updateRequest;
+
+        registeredTopics = getFullTopicList(topics.isEmpty() ? filter.dataTopics()
+                : topics.stream().map("DATA/"::concat).toList());
+
+        synchronized (lock) {
+            // First update is against zero
+            firstUpdateSent = false;
+            snapshots.addLast(Map.of());
+        }
+        // Register first so we never miss an update
+        register(context);
+        // Ensure that we always do an initial update
+        tryUpdate();
+    }
+
+    public List<String> getRegisteredTopics() {
+        return registeredTopics;
+    }
+
+    private List<String> getFullTopicList(List<String> dataTopics) {
+        Stream<String> dataAndMetadata = dataTopics.stream()
+                .flatMap(s -> Stream.of(s, metadataTopic(s)));
+
+        return Stream.concat(dataAndMetadata, lifecycleTopics(dataTopics))
+                .toList();
+    }
+
+    private String metadataTopic(String s) {
+        return "META".concat(s);
+    }
+
+    /**
+     * We assume that we're interested in all lifecycle events for
+     * all providers that are referenced
+     * @param dataTopics
+     * @return
+     */
+    private Stream<String> lifecycleTopics(List<String> dataTopics) {
+        Map<String, Set<String>> modelsAndProviders = new HashMap<>();
+        boolean fullWildcard = false;
+        for(String dataTopic : dataTopics) {
+            String[] split = dataTopic.split("/");
+            if(split.length < 2) {
+                LOG.warn("Unexpected data topic format {}", dataTopic);
+            } else if (split.length == 2) {
+                if("*".equals(split[1])) {
+                    fullWildcard = true;
+                    break;
+                }
+            } else {
+                modelsAndProviders.merge(split[1], Set.of(split[2]),
+                        (a,b) -> Stream.concat(a.stream(), b.stream()).collect(Collectors.toSet()));
+            }
+        }
+
+        if(fullWildcard) {
+            return Stream.of("LIFECYCLE/*");
+        }
+
+        Function<Entry<String, Set<String>>, Stream<String>> mapper = e -> {
+            String model = e.getKey();
+            Set<String> providers = e.getValue();
+            if(providers.contains("*")) {
+                return Stream.of(String.format("LIFECYCLE/%s/*", model));
+            } else {
+                return providers.stream().map(p -> String.format("LIFECYCLE/%s/%s/*", model, p));
+            }
+        };
+
+        return modelsAndProviders.entrySet().stream()
+                .flatMap(mapper);
+    }
+
+    private void checkUpdate(Function<Map<String, ProviderSnapshot>, State> check) {
+        Map<String, ProviderSnapshot> ps;
+        synchronized (lock) {
+            if(updateInProgress) {
+                pendingChecks.addFirst(check);
+                return;
+            }
+            ps = snapshots.peekLast();
+        }
+        if(check.apply(ps) == State.OUTDATED) {
+            tryUpdate();
+        }
+    }
+
+    private void tryUpdate() {
+        boolean doUpdate;
+        synchronized (lock) {
+            if(updateInProgress) {
+                doUpdate = false;
+            } else {
+                doUpdate = true;
+                updateInProgress = true;
+            }
+        }
+        if(doUpdate) {
+            updateRequest.get()
+                .onSuccess(this::successfulUpdate)
+                .onFailure(t -> LOG.error("Failed to update the snapshot", t));
+        }
+    }
+
+    private void successfulUpdate(List<ProviderSnapshot> newSnapshot) {
+        Map<String, ProviderSnapshot> snapshotMap = newSnapshot.stream()
+                .collect(toUnmodifiableMap(ProviderSnapshot::getName, identity()));
+        Deque<Function<Map<String, ProviderSnapshot>,State>> queuedChecks;
+        synchronized (lock) {
+            snapshots.addLast(snapshotMap);
+            updateInProgress = false;
+            queuedChecks = pendingChecks;
+            pendingChecks = new LinkedList<>();
+        }
+        // Notify the listener
+        notifyListener();
+        // Check to see if we need to do more updates
+        checks: for (Function<Map<String, ProviderSnapshot>, State> check : queuedChecks) {
+            State state = check.apply(snapshotMap);
+            switch (state) {
+            // If oudated trigger an update and then stop checking
+            case OUTDATED:
+                tryUpdate();
+                break checks;
+            // If up to date then all subsequent checks must also be up to date
+            case UP_TO_DATE: break checks;
+            // If "skip" i.e. unknown then keep checking
+            case SKIP: continue checks;
+            default:
+                LOG.error("Unexpected check state {}", state);
+            }
+        }
+    }
+
+    private void notifyListener() {
+        try {
+            notificationSemaphore.acquire();
+        } catch (InterruptedException e) {
+            LOG.warn("Interrupted while waiting to deliver snapshot updates. This update will be skipped.", e);
+            return;
+        }
+        try {
+            boolean firstUpdateSent;
+            Map<String, ProviderSnapshot> previous;
+            Map<String, ProviderSnapshot> next;
+            synchronized (lock) {
+                firstUpdateSent = this.firstUpdateSent;
+                this.firstUpdateSent = true;
+                previous = snapshots.removeFirst();
+                next = snapshots.peekFirst();
+            }
+
+            Map<String, ProviderSnapshot> arriving = next.entrySet().stream()
+                    .filter(e -> !previous.containsKey(e.getKey()))
+                    .collect(toUnmodifiableMap(Entry::getKey, Entry::getValue));
+            Set<String> departing = previous.keySet().stream()
+                    .filter(s -> !next.containsKey(s))
+                    .collect(toUnmodifiableSet());
+
+            Map<String, ProviderSnapshot> modified = next.entrySet().stream()
+                    .filter(e -> previous.containsKey(e.getKey()))
+                    .filter(e -> isUpdated(previous.get(e.getKey()), e.getValue()))
+                    .collect(toUnmodifiableMap(Entry::getKey, Entry::getValue));
+
+            if(firstUpdateSent && arriving.isEmpty() && modified.isEmpty() && departing.isEmpty()) {
+                LOG.debug("Skipping empty update for subscription {} in session {}", subscriptionId, sessionId);
+            } else {
+                snapshotUpdate.accept(new SnapshotUpdate(arriving, modified, departing));
+            }
+        } finally {
+            notificationSemaphore.release();
+        }
+    }
+
+    private static final List<Function<LinkedProviderSnapshot, Object>> LINKED_PROVIDER_FIELDS = List.of(
+            LinkedProviderSnapshot::getModelPackageUri, LinkedProviderSnapshot::getModelName,
+            LinkedProviderSnapshot::getName, LinkedProviderSnapshot::getFriendlyName,
+            LinkedProviderSnapshot::getDescription, LinkedProviderSnapshot::getLocation,
+            LinkedProviderSnapshot::getIcon);
+    private static final List<Function<ResourceSnapshot, Object>> RESOURCE_FIELDS = List.of(
+            ResourceSnapshot::getName, ResourceSnapshot::getValue, ResourceSnapshot::getMetadata,
+            ResourceSnapshot::getResourceType, ResourceSnapshot::getType, ResourceSnapshot::getValueType,
+            ResourceSnapshot::getArguments);
+
+    private boolean isUpdated(ProviderSnapshot previous, ProviderSnapshot next) {
+        if(!(Objects.equals(previous.getModelPackageUri(), next.getModelPackageUri()) &&
+                Objects.equals(previous.getModelName(), next.getModelName()))) {
+            return true;
+        }
+
+        List<ServiceSnapshot> previousServices = previous.getServices();
+        List<ServiceSnapshot> nextServices = next.getServices();
+        if(previousServices.size() != nextServices.size()) {
+            return true;
+        }
+
+        for(int i = 0; i < previousServices.size(); i++) {
+            ServiceSnapshot ps = previousServices.get(i);
+            ServiceSnapshot ns = nextServices.get(i);
+            if(!Objects.equals(ps.getName(), ns.getName())) {
+                return true;
+            }
+            List<ResourceSnapshot> previousResources = ps.getResources();
+            List<ResourceSnapshot> nextResources = ns.getResources();
+            if(previousResources.size() != nextResources.size()) {
+                return true;
+            }
+            for(int j = 0; j < previousResources.size(); j++) {
+                ResourceSnapshot pr = previousResources.get(j);
+                ResourceSnapshot nr = nextResources.get(j);
+                if(!RESOURCE_FIELDS.stream().allMatch(f -> Objects.equals(f.apply(pr), f.apply(nr)))) {
+                    return true;
+                }
+            }
+        }
+
+        // Linked Providers
+        List<LinkedProviderSnapshot> previousLinks = previous.getLinkedProviders();
+        List<LinkedProviderSnapshot> nextLinks = next.getLinkedProviders();
+        if(previousLinks.size() != nextLinks.size()) {
+            return true;
+        }
+
+        for(int i = 0; i < previousLinks.size(); i++) {
+            LinkedProviderSnapshot pl = previousLinks.get(i);
+            LinkedProviderSnapshot nl = nextLinks.get(i);
+            if(!LINKED_PROVIDER_FIELDS.stream().allMatch(f -> Objects.equals(f.apply(pl), f.apply(nl)))) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private boolean containsService(Map<String, ProviderSnapshot> snapshots, ResourceNotification rn) {
+        return Optional.ofNullable(snapshots.get(rn.provider()))
+                .map(ps -> ps.getService(rn.service()))
+                .isPresent();
+    }
+
+    private boolean containsResource(Map<String, ProviderSnapshot> snapshots, ResourceNotification rn) {
+        return Optional.ofNullable(snapshots.get(rn.provider()))
+                .map(ps -> ps.getResource(rn.service(), rn.resource()))
+                .isPresent();
+    }
+
+    protected void notifyLifecycle(String topic, LifecycleNotification ln) {
+
+        switch(ln.status()) {
+            case PROVIDER_CREATED:
+            case PROVIDER_DELETED:
+                if(!authorizer.hasProviderPermission(DESCRIBE, ln.modelPackageUri(), ln.model(), ln.provider())) {
+                    // We are not allowed to see this change, so don't bother checking for an update
+                    return;
+                } else {
+                    if(ln.status() == Status.PROVIDER_CREATED) {
+                        // A new provider may be interesting
+                        checkUpdate(m -> m.containsKey(ln.provider()) ? State.UP_TO_DATE : State.OUTDATED);
+                    } else {
+                        checkUpdate(m -> m.containsKey(ln.provider()) ? State.OUTDATED : State.UP_TO_DATE);
+                    }
+                }
+                break;
+            case RESOURCE_CREATED:
+            case RESOURCE_DELETED:
+                if(!authorizer.hasResourcePermission(DESCRIBE, ln.modelPackageUri(), ln.model(), ln.provider(), ln.service(), ln.resource())) {
+                    // We are not allowed to see this change, so don't bother checking for an update
+                    return;
+                } else {
+                    if(ln.status() == Status.RESOURCE_CREATED) {
+                        // A new resource may be interesting
+                        checkUpdate(m -> containsResource(m, ln) ? State.UP_TO_DATE : State.OUTDATED);
+                    } else {
+                        checkUpdate(m -> containsResource(m, ln) ? State.OUTDATED : State.UP_TO_DATE);
+                    }
+                }
+                break;
+            case SERVICE_CREATED:
+            case SERVICE_DELETED:
+                // A new service may be interesting
+                if(!authorizer.hasServicePermission(DESCRIBE, ln.modelPackageUri(), ln.model(), ln.provider(), ln.service())) {
+                    // We are not allowed to see this change, so don't bother checking for an update
+                    return;
+                } else {
+                    if(ln.status() == Status.RESOURCE_CREATED) {
+                        // A new service may be interesting
+                        checkUpdate(m -> containsService(m, ln) ? State.UP_TO_DATE : State.OUTDATED);
+                    } else {
+                        checkUpdate(m -> containsService(m, ln) ? State.OUTDATED : State.UP_TO_DATE);
+                    }
+                }
+                break;
+            default:
+                LOG.warn("Unrecognised lifecycle status {}. Denying access to the notification", ln.status());
+                return;
+        }
+    }
+
+    protected void notifyData(String topic, ResourceDataNotification rdn) {
+        if(!authorizer.hasResourcePermission(READ, rdn.modelPackageUri(), rdn.model(), rdn.provider(), rdn.service(), rdn.resource())) {
+            return;
+        }
+        checkUpdate(m -> Optional.ofNullable(m.get(rdn.provider()))
+                .map(ps -> ps.getResource(rdn.service(), rdn.resource()))
+                .map(rs -> checkUpdate(rs.getValue(), new DefaultTimedValue<>(rdn.newValue(), rdn.timestamp())))
+                .orElseGet(() -> checkResourceIsWanted(rdn)));
+    }
+
+    private State checkUpdate(TimedValue<?> snapshot, TimedValue<?> event) {
+        if(snapshot.isEmpty() || snapshot.getTimestamp().isBefore(event.getTimestamp())) {
+            return State.OUTDATED;
+        }
+        if(snapshot.getTimestamp().isAfter(event.getTimestamp())) {
+            return State.UP_TO_DATE;
+        }
+
+        // The two timestamps are equal. If the values are equal then skip
+        if(Objects.equals(snapshot.getValue(), event.getValue())) {
+            return State.SKIP;
+        }
+        // If we get here then we assume that we're outdated for safety
+        return State.OUTDATED;
+    }
+
+    /**
+     * Test whether the filter is interested in the resource. If yes then return OUTDATED to indicate
+     * that the snapshot should update, otherwise return SKIP to indicate no interest.
+     * @param rdn
+     * @return
+     */
+    private State checkResourceIsWanted(ResourceDataNotification rdn) {
+        ImmutableProviderSnapshot ips = new ImmutableProviderSnapshot(rdn.modelPackageUri(), rdn.model(),
+                rdn.provider(), rdn.timestamp(), List.of(new ImmutableServiceSnapshot(null, rdn.service(),
+                        List.of(new ImmutableResourceSnapshot(rdn.resource())))), List.of());
+
+        boolean wanted = filter.getProviderFilter().test(ips) &&
+        filter.getServiceFilter().test(ips.getService(rdn.service())) &&
+        filter.getResourceFilter().test(ips.getResource(rdn.service(), rdn.resource()));
+        return wanted == true ? State.OUTDATED : State.SKIP;
+    }
+
+    protected void notifyMetdata(String topic, ResourceMetaDataNotification rmn) {
+        if(!authorizer.hasResourcePermission(READ, rmn.modelPackageUri(), rmn.model(), rmn.provider(), rmn.service(), rmn.resource())) {
+            return;
+        }
+        checkUpdate(m -> Optional.ofNullable(m.get(rmn.provider()))
+                .map(ps -> ps.getResource(rmn.service(), rmn.resource()))
+                .map(rs -> rs.getMetadata().equals(rmn.newValues())? State.SKIP : State.OUTDATED)
+                .orElse(State.SKIP));
+    }
+
+    protected void notifyAction(String topic, ResourceActionNotification notification) {
+        // This is currently a no-op
+    }
+}

--- a/northbound/session/session-impl/src/main/java/org/eclipse/sensinact/northbound/session/snapshot/ImmutableResourceSnapshot.java
+++ b/northbound/session/session-impl/src/main/java/org/eclipse/sensinact/northbound/session/snapshot/ImmutableResourceSnapshot.java
@@ -24,20 +24,30 @@ import org.eclipse.sensinact.core.model.ResourceType;
 import org.eclipse.sensinact.core.model.ValueType;
 import org.eclipse.sensinact.core.snapshot.ResourceSnapshot;
 import org.eclipse.sensinact.core.snapshot.ServiceSnapshot;
+import org.eclipse.sensinact.core.twin.DefaultTimedValue;
 import org.eclipse.sensinact.core.twin.TimedValue;
 
 /**
  * A default immutable representation of a provider snapshot
  */
-record ImmutableResourceSnapshot(ServiceSnapshot service, String name, ValueType valueType, ResourceType resourceType,
+public record ImmutableResourceSnapshot(ServiceSnapshot service, String name, ValueType valueType, ResourceType resourceType,
         Class<?> type, TimedValue<?> value, Map<String, Object> metadata, List<Entry<String, Class<?>>> arguments,
         boolean multiple) implements ResourceSnapshot {
 
-    ImmutableResourceSnapshot {
+    public ImmutableResourceSnapshot {
         // We must be careful as <code>null</code> is a valid metadata value
         metadata = metadata == null ? Map.of() :
             metadata.entrySet().stream().anyMatch(e -> e.getValue() == null || e.getKey() == null) ?
             Collections.unmodifiableMap(new HashMap<>(metadata)) : Map.copyOf(metadata);
+    }
+
+    /**
+     * A constructor for making a fake resource snapshot, typically used as input to a
+     * fake {@link ImmutableServiceSnapshot}
+     * @param name
+     */
+    public ImmutableResourceSnapshot(String name) {
+        this(null, name, ValueType.FIXED, ResourceType.PROPERTY, Integer.class, new DefaultTimedValue<>(), null, null, false);
     }
 
     ImmutableResourceSnapshot(ImmutableServiceSnapshot ss, ResourceSnapshot r) {

--- a/northbound/session/session-impl/src/main/java/org/eclipse/sensinact/northbound/session/snapshot/ImmutableServiceSnapshot.java
+++ b/northbound/session/session-impl/src/main/java/org/eclipse/sensinact/northbound/session/snapshot/ImmutableServiceSnapshot.java
@@ -28,11 +28,12 @@ public record ImmutableServiceSnapshot(ProviderSnapshot provider, String name,
 
     public ImmutableServiceSnapshot {
         resources = resources == null ? List.of() : resources.stream()
-                .map(r -> r instanceof ImmutableResourceSnapshot ? r : new ImmutableResourceSnapshot(this, r))
+                .map(r -> r instanceof ImmutableResourceSnapshot ir && ir.getService() == this ?
+                        r : new ImmutableResourceSnapshot(this, r))
                 .toList();
     }
 
-    public ImmutableServiceSnapshot(ImmutableProviderSnapshot ps, ServiceSnapshot s) {
+    ImmutableServiceSnapshot(ImmutableProviderSnapshot ps, ServiceSnapshot s) {
         this(ps, s.getName(), s.getResources());
     }
 

--- a/northbound/session/session-impl/src/test/java/org/eclipse/sensinact/northbound/session/integration/SessionSubscribeTest.java
+++ b/northbound/session/session-impl/src/test/java/org/eclipse/sensinact/northbound/session/integration/SessionSubscribeTest.java
@@ -13,10 +13,12 @@
 package org.eclipse.sensinact.northbound.session.integration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
@@ -26,12 +28,22 @@ import org.eclipse.sensinact.core.command.GatewayThread;
 import org.eclipse.sensinact.core.notification.ResourceDataNotification;
 import org.eclipse.sensinact.core.push.DataUpdate;
 import org.eclipse.sensinact.core.push.dto.GenericDto;
+import org.eclipse.sensinact.core.snapshot.ICriterion;
 import org.eclipse.sensinact.core.twin.SensinactDigitalTwin;
 import org.eclipse.sensinact.core.twin.SensinactProvider;
+import org.eclipse.sensinact.filters.resource.selector.api.ResourceSelector;
+import org.eclipse.sensinact.filters.resource.selector.api.ResourceSelector.ProviderSelection;
+import org.eclipse.sensinact.filters.resource.selector.api.ResourceSelector.ResourceSelection;
+import org.eclipse.sensinact.filters.resource.selector.api.ResourceSelectorFilterFactory;
+import org.eclipse.sensinact.filters.resource.selector.api.Selection;
+import org.eclipse.sensinact.filters.resource.selector.api.ValueSelection;
+import org.eclipse.sensinact.filters.resource.selector.api.ValueSelection.CheckType;
+import org.eclipse.sensinact.filters.resource.selector.api.ValueSelection.OperationType;
 import org.eclipse.sensinact.model.core.provider.ProviderPackage;
 import org.eclipse.sensinact.northbound.security.api.UserInfo;
 import org.eclipse.sensinact.northbound.session.SensiNactSession;
 import org.eclipse.sensinact.northbound.session.SensiNactSessionManager;
+import org.eclipse.sensinact.northbound.session.SnapshotUpdate;
 import org.eclipse.sensinact.northbound.session.impl.SessionManager;
 import org.eclipse.sensinact.northbound.session.impl.TestUserInfo;
 import org.junit.jupiter.api.AfterEach;
@@ -48,6 +60,7 @@ public class SessionSubscribeTest {
     private static final UserInfo ANON = new TestUserInfo("<ANON>", false);
     private static final UserInfo BOB = new TestUserInfo("bob", true);
 
+    private static final String MODEL_URI = "https://sensinact.eclipse.org/test/model";
     private static final String MODEL = "model";
     private static final String PROVIDER = "provider";
     private static final String PROVIDER_TOPIC = MODEL + "/" + PROVIDER + "/*";
@@ -60,7 +73,13 @@ public class SessionSubscribeTest {
     SensiNactSessionManager sessionManager;
 
     @InjectService
+    GatewayThread thread;
+
+    @InjectService
     DataUpdate push;
+
+    @InjectService
+    ResourceSelectorFilterFactory filterFactory;
 
     @AfterEach
     void stop() {
@@ -99,15 +118,7 @@ public class SessionSubscribeTest {
 
         assertNull(queue.poll(500, TimeUnit.MILLISECONDS));
 
-        GenericDto dto = new GenericDto();
-        dto.model = MODEL;
-        dto.provider = PROVIDER;
-        dto.service = SERVICE;
-        dto.resource = RESOURCE;
-        dto.value = VALUE;
-        dto.type = Integer.class;
-
-        push.pushUpdate(dto);
+        pushDto(VALUE);
 
         ResourceDataNotification notification = queue.poll(1, TimeUnit.SECONDS);
 
@@ -152,9 +163,7 @@ public class SessionSubscribeTest {
 
         assertNull(queue.poll(500, TimeUnit.MILLISECONDS));
 
-        dto.value = VALUE_2;
-
-        push.pushUpdate(dto);
+        pushDto(VALUE_2);
 
         notification = queue.poll(1, TimeUnit.SECONDS);
 
@@ -168,6 +177,23 @@ public class SessionSubscribeTest {
 
         assertNull(queue.poll(500, TimeUnit.MILLISECONDS));
 
+    }
+
+    private void pushDto(Integer value) {
+        pushDto(PROVIDER, value);
+    }
+
+    private void pushDto(String provider, Integer value) {
+        GenericDto dto = new GenericDto();
+        dto.modelPackageUri = MODEL_URI;
+        dto.model = MODEL;
+        dto.provider = provider;
+        dto.service = SERVICE;
+        dto.resource = RESOURCE;
+        dto.value = value;
+        dto.type = Integer.class;
+
+        push.pushUpdate(dto);
     }
 
     /**
@@ -185,16 +211,153 @@ public class SessionSubscribeTest {
 
         assertNull(queue.poll(500, TimeUnit.MILLISECONDS));
 
-        GenericDto dto = new GenericDto();
-        dto.model = MODEL;
-        dto.provider = PROVIDER;
-        dto.service = SERVICE;
-        dto.resource = RESOURCE;
-        dto.value = VALUE;
-        dto.type = Integer.class;
+        pushDto(VALUE);
 
-        push.pushUpdate(dto);
+        assertNull(queue.poll(1, TimeUnit.SECONDS));
+    }
 
+    /**
+     * Show that data updates result in events received by subscribers
+     *
+     * @throws Exception
+     */
+    @Test
+    void snapshotSubscribe() throws Exception {
+
+        final String beforeProvider = "before";
+        final String beforeNoMatch = "beforeNoMatch";
+
+        BlockingQueue<SnapshotUpdate> queue = new ArrayBlockingQueue<>(32);
+
+        ResourceSelection friendlyName = new ResourceSelection(new Selection(ProviderPackage.Literals.PROVIDER__ADMIN.getName()),
+                new Selection(ProviderPackage.Literals.ADMIN__FRIENDLY_NAME.getName()),
+                List.of());
+
+        ResourceSelection highValue = new ResourceSelection(new Selection(SERVICE), new Selection(RESOURCE),
+                List.of(new ValueSelection(VALUE.toString(), OperationType.GREATER_THAN, false, CheckType.VALUE)));
+
+        ICriterion criterion = filterFactory.parseResourceSelector(
+                new ResourceSelector(List.of(new ProviderSelection(new Selection(MODEL_URI), new Selection(MODEL), null,
+                        List.of(friendlyName, highValue), List.of())), List.of()));
+
+        pushDto(beforeProvider, VALUE_2);
+        pushDto(beforeNoMatch, VALUE);
+
+        SensiNactSession session = sessionManager.getDefaultSession(BOB);
+        session.subscribe(criterion, queue::add);
+
+        SnapshotUpdate update = queue.poll(1, TimeUnit.SECONDS);
+        assertNotNull(update);
+
+        // Just the initial matching provider
+        assertEquals(1, update.arriving().size());
+        assertEquals(0, update.modified().size());
+        assertEquals(0, update.departing().size());
+
+        assertEquals(Set.of(beforeProvider), update.arriving().keySet());
+        assertEquals(VALUE_2,
+                update.arriving().get(beforeProvider).getResource(SERVICE, RESOURCE).getValue().getValue());
+        assertFalse(update.arriving().get(beforeProvider).getResource(
+                ProviderPackage.Literals.PROVIDER__ADMIN.getName(),
+                ProviderPackage.Literals.ADMIN__FRIENDLY_NAME.getName()).getValue().isEmpty());
+
+        // Modified match
+        pushDto(beforeProvider, VALUE + 1);
+
+        update = queue.poll(1, TimeUnit.SECONDS);
+        assertNotNull(update);
+
+        assertEquals(0, update.arriving().size());
+        assertEquals(1, update.modified().size());
+        assertEquals(0, update.departing().size());
+
+        assertEquals(Set.of(beforeProvider), update.modified().keySet());
+        assertEquals(VALUE + 1,
+                update.modified().get(beforeProvider).getResource(SERVICE, RESOURCE).getValue().getValue());
+        assertFalse(update.modified().get(beforeProvider).getResource(
+                ProviderPackage.Literals.PROVIDER__ADMIN.getName(),
+                ProviderPackage.Literals.ADMIN__FRIENDLY_NAME.getName()).getValue().isEmpty());
+
+        // New match
+        pushDto(beforeNoMatch, VALUE_2);
+
+        update = queue.poll(1, TimeUnit.SECONDS);
+        assertNotNull(update);
+
+        assertEquals(1, update.arriving().size());
+        assertEquals(0, update.modified().size());
+        assertEquals(0, update.departing().size());
+
+        assertEquals(Set.of(beforeNoMatch), update.arriving().keySet());
+        assertEquals(VALUE_2,
+                update.arriving().get(beforeNoMatch).getResource(SERVICE, RESOURCE).getValue().getValue());
+        assertFalse(update.arriving().get(beforeNoMatch).getResource(
+                ProviderPackage.Literals.PROVIDER__ADMIN.getName(),
+                ProviderPackage.Literals.ADMIN__FRIENDLY_NAME.getName()).getValue().isEmpty());
+
+        thread.execute(new AbstractTwinCommand<Void>() {
+            @Override
+            protected Promise<Void> call(SensinactDigitalTwin twin, PromiseFactory pf) {
+                SensinactProvider sp = twin.getProvider(beforeProvider);
+                if(sp != null) {
+                    sp.delete();
+                }
+                return pf.resolved(null);
+            }
+        });
+
+        update = queue.poll(1, TimeUnit.SECONDS);
+        assertNotNull(update);
+
+        assertEquals(0, update.arriving().size());
+        assertEquals(0, update.modified().size());
+        assertEquals(1, update.departing().size());
+
+        assertEquals(Set.of(beforeProvider), update.departing());
+
+        assertNull(queue.poll(500, TimeUnit.MILLISECONDS));
+    }
+
+    /**
+     * Show that data updates result in events received by subscribers
+     *
+     * @throws Exception
+     */
+    @Test
+    void basicSnapshotSubscribeWithoutPermission() throws Exception {
+
+        final String beforeProvider = "before";
+        final String beforeNoMatch = "beforeNoMatch";
+
+        BlockingQueue<SnapshotUpdate> queue = new ArrayBlockingQueue<>(32);
+
+        ResourceSelection friendlyName = new ResourceSelection(new Selection(ProviderPackage.Literals.PROVIDER__ADMIN.getName()),
+                new Selection(ProviderPackage.Literals.ADMIN__FRIENDLY_NAME.getName()),
+                List.of());
+
+        ResourceSelection highValue = new ResourceSelection(new Selection(SERVICE), new Selection(RESOURCE),
+                List.of(new ValueSelection(VALUE.toString(), OperationType.GREATER_THAN, false, CheckType.VALUE)));
+
+        ICriterion criterion = filterFactory.parseResourceSelector(
+                new ResourceSelector(List.of(new ProviderSelection(new Selection(MODEL_URI), new Selection(MODEL), null,
+                        List.of(friendlyName, highValue), List.of())), List.of()));
+
+        pushDto(beforeProvider, VALUE_2);
+        pushDto(beforeNoMatch, VALUE);
+
+        SensiNactSession session = sessionManager.getDefaultSession(ANON);
+        session.subscribe(criterion, queue::add);
+
+        SnapshotUpdate update = queue.poll(1, TimeUnit.SECONDS);
+        assertNotNull(update);
+
+        // No providers visible at all
+        assertEquals(0, update.arriving().size());
+        assertEquals(0, update.modified().size());
+        assertEquals(0, update.departing().size());
+
+        // New match not visible either
+        pushDto(beforeNoMatch, VALUE_2);
         assertNull(queue.poll(1, TimeUnit.SECONDS));
     }
 }


### PR DESCRIPTION
This commit updates the SensinactSession to include a filtered snapshot subscription, allowing callers to supply a callback which will be notified with the initial snapshot state, and then deltas showing changes to the snapshot that would be returned. This should be much more efficient than polling