### PR TITLE
Ensure that listener registrations happen on a different thread

### DIFF
--- a/northbound/session/session-impl/src/main/java/org/eclipse/sensinact/northbound/session/impl/AbstractSensinactSessionEventManager.java
+++ b/northbound/session/session-impl/src/main/java/org/eclipse/sensinact/northbound/session/impl/AbstractSensinactSessionEventManager.java
@@ -17,6 +17,7 @@ import static org.osgi.service.typedevent.TypedEventConstants.TYPED_EVENT_TOPICS
 import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.sensinact.core.authorization.Authorizer;
@@ -41,7 +42,8 @@ public abstract class AbstractSensinactSessionEventManager
     protected final Authorizer authorizer;
 
     private final List<String> requestedTopics;
-    private AtomicReference<ServiceRegistration<?>> registration = new AtomicReference<ServiceRegistration<?>>();
+    private final AtomicInteger state = new AtomicInteger(0);
+    private final AtomicReference<ServiceRegistration<?>> registration = new AtomicReference<ServiceRegistration<?>>();
 
 
     public AbstractSensinactSessionEventManager(String sessionId,
@@ -56,7 +58,10 @@ public abstract class AbstractSensinactSessionEventManager
      * To be called in the sub-class constructor once registered topics are available
      * @param context
      */
-    protected void register(BundleContext context) {
+    public void register(BundleContext context) {
+        if(!state.compareAndSet(0, 1)) {
+            throw new IllegalStateException("This listener has already been registered");
+        }
         List<String> registeredTopics = getRegisteredTopics();
         if(registeredTopics.isEmpty()) {
             throw new IllegalArgumentException("No topics are registered");
@@ -64,6 +69,9 @@ public abstract class AbstractSensinactSessionEventManager
         registration.set(
                 context.registerService(TypedEventHandler.class, this,
                         new Hashtable<>(Map.of(TYPED_EVENT_TOPICS, registeredTopics))));
+        if(state.get() != 1) {
+            destroy();
+        }
     }
 
     public List<String> getRequestedTopics() {
@@ -73,6 +81,7 @@ public abstract class AbstractSensinactSessionEventManager
     public abstract List<String> getRegisteredTopics();
 
     public void destroy() {
+        state.set(2);
         try {
             ServiceRegistration<?> reg = registration.getAndSet(null);
             if(reg != null) {

--- a/northbound/session/session-impl/src/main/java/org/eclipse/sensinact/northbound/session/impl/SensiNactSessionImpl.java
+++ b/northbound/session/session-impl/src/main/java/org/eclipse/sensinact/northbound/session/impl/SensiNactSessionImpl.java
@@ -126,15 +126,18 @@ public class SensiNactSessionImpl implements SensiNactSession {
 
     private final PreAuthorizer preAuthorizer;
 
+    private final PromiseFactory promiseFactory;
+
     public SensiNactSessionImpl(final UserInfo user, final PreAuthorizer preAuthorizer, final Authorizer authorizer,
             final GatewayThread thread, final Duration expiry, final SensiNactSessionActivityChecker activityChecker,
-            final BundleContext context) {
+            final BundleContext context, PromiseFactory promiseFactory) {
         this.user = user;
         this.preAuthorizer = Objects.requireNonNull(preAuthorizer, "No PreAuthorizer given");
         this.authorizer = Objects.requireNonNull(authorizer, "No Authorizer given");
         this.thread = thread;
         this.activityChecker = activityChecker;
         this.context = context;
+        this.promiseFactory = promiseFactory;
         Objects.requireNonNull(expiry, "No session duration given");
         if(expiry.isZero() || expiry.isNegative()) {
             // Infinite session
@@ -154,7 +157,7 @@ public class SensiNactSessionImpl implements SensiNactSession {
     @Override
     public String addListener(List<String> topics, ClientDataListener cdl, ClientMetadataListener cml,
             ClientLifecycleListener cll, ClientActionListener cal) {
-        return doAddListener(subId -> new SensinactSessionEventListener(context, sessionId,
+        return doAddListener(subId -> new SensinactSessionEventListener(sessionId,
                 subId, topics, authorizer, cll, cdl, cml, cal));
     }
 
@@ -185,6 +188,10 @@ public class SensiNactSessionImpl implements SensiNactSession {
         if(destroy) {
             ssem.destroy();
             throw new IllegalStateException("The session is expired");
+        } else {
+            // Asynchronously register to ensure that the session id can be returned
+            // while blocking calls in the listeners
+            promiseFactory.executor().execute(() -> ssem.register(context));
         }
         return subscriptionId;
     }
@@ -202,7 +209,7 @@ public class SensiNactSessionImpl implements SensiNactSession {
 
     @Override
     public String subscribe(ICriterion filter, Consumer<SnapshotUpdate> updateListener) {
-        return doAddListener(subId -> new SensinactSessionSnapshotListener(context, sessionId,
+        return doAddListener(subId -> new SensinactSessionSnapshotListener(sessionId,
                 subId, List.of(), authorizer, filter, updateListener,
                 () -> asyncFilteredSnapshot(filter, EnumSet.of(SnapshotOption.INCLUDE_LINKED_PROVIDERS_FULL))));
     }

--- a/northbound/session/session-impl/src/main/java/org/eclipse/sensinact/northbound/session/impl/SensinactSessionEventListener.java
+++ b/northbound/session/session-impl/src/main/java/org/eclipse/sensinact/northbound/session/impl/SensinactSessionEventListener.java
@@ -47,7 +47,7 @@ public class SensinactSessionEventListener extends AbstractSensinactSessionEvent
     private final List<String> registeredTopics;
 
 
-    public SensinactSessionEventListener(BundleContext context, String sessionId,
+    public SensinactSessionEventListener(String sessionId,
             String subscriptionId, List<String> topics, Authorizer authorizer,
             ClientLifecycleListener lifecycleListener, ClientDataListener dataListener,
             ClientMetadataListener metadataListener, ClientActionListener actionListener) {
@@ -87,7 +87,6 @@ public class SensinactSessionEventListener extends AbstractSensinactSessionEvent
             throw new IllegalArgumentException("At least one listener type must be specified");
         }
         registeredTopics = prefixes.stream().flatMap(p -> topics.stream().map(p::concat)).toList();
-        register(context);
     }
 
     public List<String> getRegisteredTopics() {

--- a/northbound/session/session-impl/src/main/java/org/eclipse/sensinact/northbound/session/impl/SensinactSessionSnapshotListener.java
+++ b/northbound/session/session-impl/src/main/java/org/eclipse/sensinact/northbound/session/impl/SensinactSessionSnapshotListener.java
@@ -82,7 +82,7 @@ public class SensinactSessionSnapshotListener extends AbstractSensinactSessionEv
     private final Semaphore notificationSemaphore = new Semaphore(1);
 
 
-    public SensinactSessionSnapshotListener(BundleContext context, String sessionId,
+    public SensinactSessionSnapshotListener(String sessionId,
             String subscriptionId, List<String> topics, Authorizer authorizer,
             ICriterion filter, Consumer<SnapshotUpdate> snapshotUpdate,
             Supplier<Promise<List<ProviderSnapshot>>> updateRequest) {
@@ -100,8 +100,12 @@ public class SensinactSessionSnapshotListener extends AbstractSensinactSessionEv
             firstUpdateSent = false;
             snapshots.addLast(Map.of());
         }
+    }
+
+    @Override
+    public void register(BundleContext context) {
         // Register first so we never miss an update
-        register(context);
+        super.register(context);
         // Ensure that we always do an initial update
         tryUpdate();
     }

--- a/northbound/session/session-impl/src/main/java/org/eclipse/sensinact/northbound/session/impl/SessionManager.java
+++ b/northbound/session/session-impl/src/main/java/org/eclipse/sensinact/northbound/session/impl/SessionManager.java
@@ -107,7 +107,7 @@ public class SessionManager
     /**
      * Scheduler for session expiration checks
      */
-    private ScheduledExecutorService activityCheckScheduler;
+    private ScheduledExecutorService sessionWorkers;
 
     /**
      * Promise factory for scheduling session expiration checks
@@ -244,10 +244,10 @@ public class SessionManager
                     activityCheckPeriod, sessionActivityThreshold, sessionActivityExtension);
 
             // Schedule the periodic activity check task
-            this.activityCheckScheduler = Executors.newScheduledThreadPool(4,
-                    r -> new Thread(r, "sensinact-session-activity-checker"));
-            this.promiseFactory = new PromiseFactory(this.activityCheckScheduler);
-            this.activityCheckScheduler.scheduleAtFixedRate(this::checkSessionsLiveness, activityCheckPeriod,
+            this.sessionWorkers = Executors.newScheduledThreadPool(4,
+                    r -> new Thread(r, "sensinact-session-workers"));
+            this.promiseFactory = new PromiseFactory(this.sessionWorkers);
+            this.sessionWorkers.scheduleAtFixedRate(this::checkSessionsLiveness, activityCheckPeriod,
                     activityCheckPeriod, TimeUnit.SECONDS);
         }
 
@@ -264,9 +264,9 @@ public class SessionManager
         }
 
         // Stop the scheduler for session expiration checks
-        if (activityCheckScheduler != null) {
-            activityCheckScheduler.shutdownNow();
-            activityCheckScheduler = null;
+        if (sessionWorkers != null) {
+            sessionWorkers.shutdownNow();
+            sessionWorkers = null;
         }
 
         List<SensiNactSessionImpl> toInvalidate;
@@ -586,7 +586,7 @@ public class SessionManager
         }
 
         final SensiNactSessionImpl session = new SensiNactSessionImpl(user, preAuthorizer, authorizer, thread, expiry,
-                activityChecker, context);
+                activityChecker, context, promiseFactory);
         String sessionId = session.getSessionId();
 
         // Add an expiration listener to clean up session when explicitly expired


### PR DESCRIPTION
Listener registrations may start sending callbacks immediately as soon as they are registered, so it is common to use a mutex to ensure that the subscription id is available before the first callback is processed. This, however, causes a problem if the callback occurs on the registering thread, which can happen if, for example, the callback is chained from a resolved promise.

This commit fixes the issue by separating the listener registration from the listener construction, and using the session manager threadpool to perform the registration.