### PR TITLE
Add REST support for snapshot notification subscriptions

### DIFF
--- a/northbound/rest/src/main/java/org/eclipse/sensinact/northbound/rest/api/IRestNorthbound.java
+++ b/northbound/rest/src/main/java/org/eclipse/sensinact/northbound/rest/api/IRestNorthbound.java
@@ -44,6 +44,13 @@ public interface IRestNorthbound {
     @POST
     AbstractResultDTO getSnapshot(@QueryParam("metadata") @DefaultValue("false") boolean includeMetadata, List<ResourceSelector> filter);
 
+    @Path("snapshot/subscribe")
+    @GET
+    @Produces(MediaType.SERVER_SENT_EVENTS)
+    void watchSnapshots(@QueryParam("filter") String filter,
+            @QueryParam("filterLanguage") String filterLanguage,
+            @Context SseEventSink eventSink);
+
     @Path("providers")
     @GET
     AbstractResultDTO listProviders();

--- a/northbound/rest/src/main/java/org/eclipse/sensinact/northbound/rest/impl/RestNorthbound.java
+++ b/northbound/rest/src/main/java/org/eclipse/sensinact/northbound/rest/impl/RestNorthbound.java
@@ -12,26 +12,38 @@
 **********************************************************************/
 package org.eclipse.sensinact.northbound.rest.impl;
 
+import static java.util.stream.Collectors.toMap;
+import static org.eclipse.sensinact.filters.resource.selector.api.ResourceSelectorFilterFactory.RESOURCE_SELECTOR_FILTER;
 import static org.eclipse.sensinact.northbound.query.dto.query.QueryLinkDTO.LinkAction.ADD;
 import static org.eclipse.sensinact.northbound.query.dto.query.QueryLinkDTO.LinkAction.REMOVE;
+import static org.eclipse.sensinact.northbound.query.dto.query.QuerySnapshotDTO.SnapshotLinkOption.FULL;
 
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Predicate;
 
 import org.eclipse.sensinact.core.notification.ClientDataListener;
 import org.eclipse.sensinact.core.notification.ClientLifecycleListener;
 import org.eclipse.sensinact.core.notification.ResourceNotification;
+import org.eclipse.sensinact.core.snapshot.ICriterion;
+import org.eclipse.sensinact.core.snapshot.ProviderSnapshot;
+import org.eclipse.sensinact.core.twin.SensinactDigitalTwin.SnapshotOption;
 import org.eclipse.sensinact.filters.resource.selector.api.ResourceSelector;
 import org.eclipse.sensinact.northbound.query.api.AbstractQueryDTO;
 import org.eclipse.sensinact.northbound.query.api.AbstractResultDTO;
 import org.eclipse.sensinact.northbound.query.api.IQueryHandler;
+import org.eclipse.sensinact.northbound.query.api.StatusException;
 import org.eclipse.sensinact.northbound.query.dto.SensinactPath;
 import org.eclipse.sensinact.northbound.query.dto.notification.ResourceDataNotificationDTO;
 import org.eclipse.sensinact.northbound.query.dto.notification.ResourceLifecycleNotificationDTO;
+import org.eclipse.sensinact.northbound.query.dto.notification.SnapshotUpdateNotificationDTO;
 import org.eclipse.sensinact.northbound.query.dto.query.AccessMethodCallParameterDTO;
 import org.eclipse.sensinact.northbound.query.dto.query.QueryActDTO;
 import org.eclipse.sensinact.northbound.query.dto.query.QueryDescribeDTO;
@@ -41,20 +53,25 @@ import org.eclipse.sensinact.northbound.query.dto.query.QueryLinkDTO.LinkAction;
 import org.eclipse.sensinact.northbound.query.dto.query.QueryListDTO;
 import org.eclipse.sensinact.northbound.query.dto.query.QuerySetDTO;
 import org.eclipse.sensinact.northbound.query.dto.query.QuerySnapshotDTO;
+import org.eclipse.sensinact.northbound.query.dto.query.QuerySnapshotDTO.SnapshotLinkOption;
 import org.eclipse.sensinact.northbound.query.dto.query.WrappedAccessMethodCallParametersDTO;
 import org.eclipse.sensinact.northbound.query.dto.result.ErrorResultDTO;
+import org.eclipse.sensinact.northbound.query.dto.result.SnapshotProviderDTO;
 import org.eclipse.sensinact.northbound.rest.api.IRestNorthbound;
 import org.eclipse.sensinact.northbound.session.ResourceShortDescription;
 import org.eclipse.sensinact.northbound.session.SensiNactSession;
-import org.eclipse.sensinact.northbound.session.SensiNactSessionActivityChecker;
 import org.eclipse.sensinact.northbound.session.SensiNactSessionManager;
+import org.eclipse.sensinact.northbound.session.SnapshotUpdate;
 import org.osgi.util.promise.Deferred;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import jakarta.ws.rs.BadRequestException;
+import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 import jakarta.ws.rs.ext.Providers;
 import jakarta.ws.rs.sse.Sse;
@@ -96,11 +113,57 @@ public class RestNorthbound implements IRestNorthbound {
      * Prepares a new sensiNact session for the current user, with the given
      * activity checker
      */
-    private SensiNactSession prepareSSESession(final SensiNactSessionActivityChecker activityChecker) {
+    private SensiNactSession prepareSSESession(final SseEventSink eventSink) {
         final SensiNactSessionManager sessionManager = providers
                 .getContextResolver(SensiNactSessionManager.class, MediaType.WILDCARD_TYPE).getContext(null);
         final SensiNactSession restSession = getSession();
-        return sessionManager.createNewSession(restSession.getUserInfo(), activityChecker);
+        SensiNactSession sseSession = sessionManager.createNewSession(restSession.getUserInfo(), (pf, s) -> {
+            try {
+                if (eventSink.isClosed()) {
+                    // Event sink is already closed: expire the session immediately
+                    logger.debug("Event sink is closed. Expiring session {} immediately", s.getSessionId());
+                    s.expire();
+                    return pf.resolved(false);
+                }
+
+                // Send a comment to check if the connection is still alive
+                final Deferred<Boolean> deferred = pf.deferred();
+                eventSink
+                        .send(sse.newEventBuilder().comment("liveness-check").build())
+                        .toCompletableFuture()
+                        .orTimeout(10, TimeUnit.SECONDS)
+                        .handle((r, t) -> {
+                            if (t != null) {
+                                logger.error("Error handling liveness check result. Considering session inactive",
+                                        t);
+                                s.expire();
+                                deferred.fail(t);
+                            } else {
+                                deferred.resolve(true);
+                            }
+                            return null;
+                        });
+                return deferred.getPromise();
+            } catch (Exception e) {
+                // The event sink closure detection can let us come here
+                logger.error("Error sending liveness check SSE comment. Expiring session immediately", e);
+                s.expire();
+                return pf.resolved(false);
+            }
+        });
+        sseSession.addExpirationListener(s -> {
+            // Session expired: close the event sink
+            try {
+                logger.debug("SSE session {} expired. Closing event sink.", s.getSessionId());
+                if (!eventSink.isClosed()) {
+                    eventSink.send(sse.newEventBuilder().comment("session-expired").build());
+                    eventSink.close();
+                }
+            } catch (Exception e) {
+                logger.error("Error closing SSE after sensiNact session expiration", e);
+            }
+        });
+        return sseSession;
     }
 
     /**
@@ -230,6 +293,60 @@ public class RestNorthbound implements IRestNorthbound {
         return handleQuery(query);
     }
 
+    @Override
+    public void watchSnapshots(String filter, String filterLanguage, SseEventSink eventSink) {
+        if(filter == null || filter.isBlank()) {
+            throw new BadRequestException("A filter must be supplied");
+        }
+        // Create a new session, specific to this SSE connection
+        final SensiNactSession sseSession = prepareSSESession(eventSink);
+
+        ICriterion criterion;
+        try {
+            criterion = getQueryHandler().parseFilter(filter,
+                    filterLanguage == null ? RESOURCE_SELECTOR_FILTER : filterLanguage);
+        } catch (StatusException e) {
+            ErrorResultDTO errorResult = e.toErrorResult();
+            throw new WebApplicationException(Response.status(e.statusCode)
+                    .type(MediaType.APPLICATION_JSON)
+                    .entity(errorResult).build());
+        }
+
+        MultivaluedMap<String,String> queryParameters = uriInfo.getQueryParameters(true);
+        List<SnapshotLinkOption> parsed = queryParameters
+                .getOrDefault("linkOption", List.of(FULL.name())).stream()
+                .map(SnapshotLinkOption::valueOf).toList();
+        boolean includeMetadata = Optional.ofNullable(queryParameters.getFirst("includeMetadata"))
+                    .map(Boolean::parseBoolean)
+                    .orElse(Boolean.TRUE).booleanValue();
+        final Consumer<SnapshotUpdate> handler = update -> {
+            try {
+                if (eventSink.isClosed()) {
+                    // Event sink is already closed: expire the session
+                    logger.debug("Expire SSE session, as the event sink is closed");
+                    sseSession.expire();
+                    return;
+                }
+
+                IQueryHandler queryHandler = getQueryHandler();
+                Function<ProviderSnapshot, SnapshotProviderDTO> mapper = ps -> queryHandler.toSnapshotProviderDTO(ps, parsed, includeMetadata);
+
+                eventSink.send(sse.newEventBuilder().name("update").mediaType(MediaType.APPLICATION_JSON_TYPE)
+                            .data(new SnapshotUpdateNotificationDTO(
+                                    update.arriving().entrySet().stream().collect(toMap(Entry::getKey, e -> mapper.apply(e.getValue()))),
+                                    update.modified().entrySet().stream().collect(toMap(Entry::getKey, e -> mapper.apply(e.getValue()))),
+                                    update.departing())).build());
+            } catch (Exception ex) {
+                logger.error("Error sending resource data notification SSE event. Closing connection and session.", ex);
+                sseSession.expire();
+                eventSink.close();
+            }
+        };
+
+        // Register the listener
+        sseSession.subscribe(criterion, handler);
+    }
+
     /**
      * Extract the new value to set to a resource according to the given arguments
      *
@@ -340,52 +457,7 @@ public class RestNorthbound implements IRestNorthbound {
     @Override
     public void watchResource(String providerId, String serviceName, String rcName, SseEventSink eventSink) {
         // Create a new session, specific to this SSE connection
-        final SensiNactSession sseSession = prepareSSESession((pf, s) -> {
-            try {
-                if (eventSink.isClosed()) {
-                    // Event sink is already closed: expire the session immediately
-                    logger.debug("Event sink is closed. Expiring session {} immediately", s.getSessionId());
-                    s.expire();
-                    return pf.resolved(false);
-                }
-
-                // Send a comment to check if the connection is still alive
-                final Deferred<Boolean> deferred = pf.deferred();
-                eventSink
-                        .send(sse.newEventBuilder().comment("liveness-check").build())
-                        .toCompletableFuture()
-                        .orTimeout(10, TimeUnit.SECONDS)
-                        .handle((r, t) -> {
-                            if (t != null) {
-                                logger.error("Error handling liveness check result. Considering session inactive",
-                                        t);
-                                s.expire();
-                                deferred.fail(t);
-                            } else {
-                                deferred.resolve(true);
-                            }
-                            return null;
-                        });
-                return deferred.getPromise();
-            } catch (Exception e) {
-                // The event sink closure detection can let us come here
-                logger.error("Error sending liveness check SSE comment. Expiring session immediately", e);
-                s.expire();
-                return pf.resolved(false);
-            }
-        });
-        sseSession.addExpirationListener(s -> {
-            // Session expired: close the event sink
-            try {
-                logger.debug("SSE session {} expired. Closing event sink.", s.getSessionId());
-                if (!eventSink.isClosed()) {
-                    eventSink.send(sse.newEventBuilder().comment("session-expired").build());
-                    eventSink.close();
-                }
-            } catch (Exception e) {
-                logger.error("Error closing SSE after sensiNact session expiration", e);
-            }
-        });
+        final SensiNactSession sseSession = prepareSSESession(eventSink);
 
         // TODO replace this with a single-level wildcard when typed events permits it
         Predicate<ResourceNotification> filter = e -> providerId.equals(e.provider()) &&
@@ -430,10 +502,18 @@ public class RestNorthbound implements IRestNorthbound {
             }
         };
 
+        ProviderSnapshot provider = null;
+        try {
+            provider = sseSession.providerSnapshot(providerId, EnumSet.noneOf(SnapshotOption.class));
+        } catch (Exception e)  {
+            // Just swallow it
+        }
+        String topic = provider == null ? "*" : String.format("%s/%s/%s/%s", provider.getModelName(),
+                providerId, serviceName, rcName);
         // Register the listener
         // TODO use single level wildcard final String topic = String.join("/",
         // providerId, serviceName, rcName);
-        sseSession.addListener(List.of("*"), cdl, null, cll, null);
+        sseSession.addListener(List.of(topic), cdl, null, cll, null);
     }
 
     @Override

--- a/northbound/rest/src/test/java/org/eclipse/sensinact/northbound/rest/integration/notification/ResourceNotificationsTest.java
+++ b/northbound/rest/src/test/java/org/eclipse/sensinact/northbound/rest/integration/notification/ResourceNotificationsTest.java
@@ -26,13 +26,19 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.jetty.util.BlockingArrayQueue;
+import org.eclipse.sensinact.core.command.AbstractSensinactCommand;
+import org.eclipse.sensinact.core.command.GatewayThread;
+import org.eclipse.sensinact.core.model.SensinactModelManager;
 import org.eclipse.sensinact.core.notification.LifecycleNotification;
 import org.eclipse.sensinact.core.notification.ResourceDataNotification;
 import org.eclipse.sensinact.core.push.DataUpdate;
 import org.eclipse.sensinact.core.push.dto.GenericDto;
+import org.eclipse.sensinact.core.twin.SensinactDigitalTwin;
+import org.eclipse.sensinact.core.twin.SensinactProvider;
 import org.eclipse.sensinact.model.core.provider.ProviderPackage;
 import org.eclipse.sensinact.northbound.query.dto.notification.ResourceDataNotificationDTO;
 import org.eclipse.sensinact.northbound.query.dto.notification.ResourceLifecycleNotificationDTO;
+import org.eclipse.sensinact.northbound.query.dto.notification.SnapshotUpdateNotificationDTO;
 import org.eclipse.sensinact.northbound.rest.integration.TestUtils;
 import org.eclipse.sensinact.northbound.security.api.UserInfo;
 import org.eclipse.sensinact.northbound.session.SensiNactSession;
@@ -40,23 +46,28 @@ import org.eclipse.sensinact.northbound.session.SensiNactSessionManager;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.opentest4j.AssertionFailedError;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.cm.Configuration;
 import org.osgi.service.jakartars.client.SseEventSourceFactory;
+import org.osgi.service.jakartars.runtime.JakartarsServiceRuntime;
 import org.osgi.test.common.annotation.InjectBundleContext;
 import org.osgi.test.common.annotation.InjectService;
 import org.osgi.test.common.annotation.Property;
 import org.osgi.test.common.annotation.config.InjectConfiguration;
 import org.osgi.test.common.annotation.config.WithConfiguration;
 import org.osgi.test.common.service.ServiceAware;
+import org.osgi.util.promise.Promise;
+import org.osgi.util.promise.PromiseFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import jakarta.ws.rs.client.Client;
 import jakarta.ws.rs.client.ClientBuilder;
 import jakarta.ws.rs.core.Application;
+import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.sse.SseEventSource;
 import tools.jackson.jakarta.rs.cfg.JakartaRSFeature;
 import tools.jackson.jakarta.rs.json.JacksonJsonProvider;
@@ -132,9 +143,20 @@ public class ResourceNotificationsTest {
     }
 
     @AfterEach
-    void stop() {
+    void stop(@InjectService GatewayThread gt) {
         SensiNactSession session = sessionManager.getDefaultSession(USER);
         session.activeListeners().keySet().forEach(session::removeListener);
+        gt.execute(new AbstractSensinactCommand<Void>() {
+            @Override
+            protected Promise<Void> call(SensinactDigitalTwin twin, SensinactModelManager modelMgr,
+                    PromiseFactory promiseFactory) {
+                SensinactProvider sp = twin.getProvider(PROVIDER);
+                if(sp != null) {
+                    sp.delete();
+                }
+                return promiseFactory.resolved(null);
+            }
+        });
     }
 
     public static class MediaTypeAgnosticJsonProvider extends JacksonJsonProvider {
@@ -350,7 +372,7 @@ public class ResourceNotificationsTest {
     /**
      * Ensure that SSE is closed when the server expires the session
      */
-    // @Test
+    @Test
     void sseExpireOnServiceSide() throws Exception {
 
         // Ensure that no session is present at start
@@ -413,6 +435,156 @@ public class ResourceNotificationsTest {
         } finally {
             if (sseSource.isOpen()) {
                 sseSource.close();
+            }
+        }
+    }
+
+    @Nested
+    class Snapshots {
+        /**
+         * Check resource creation & update notification
+         */
+        @Test
+        void snapshotsNonExistent() throws Exception {
+
+            final String service = "new";
+            final String resource = "new-resource";
+            // We use an LDAP filter as Jersey can't cope with '{' in a query parameter
+            final String filter = "(&(PROVIDER=%s)(%s.%s=*)".formatted(PROVIDER, service, resource);
+
+            // Subscribe to a non-existent resource
+            final Client client = clientBuilder.connectTimeout(3, TimeUnit.SECONDS).register(JacksonJsonProvider.class)
+                    .build();
+            final SseEventSource sseSource = sseClient
+                    .newSource(client.target("http://localhost:8185/sensinact/").path("snapshot/subscribe")
+                            .queryParam("filter", filter).queryParam("filterLanguage", "ldap"));
+
+            final BlockingArrayQueue<SnapshotUpdateNotificationDTO> events = new BlockingArrayQueue<>();
+            sseSource.register(ise -> {
+                String name = ise.getName();
+                if (name == null) {
+                    // Liveness checks don't have a name
+                    return;
+                }
+
+                switch (name) {
+                    case "update":
+                        events.add(ise.readData(SnapshotUpdateNotificationDTO.class, MediaType.APPLICATION_JSON_TYPE));
+                        break;
+                    default:
+                        break;
+                }
+            }, Throwable::printStackTrace);
+            sseSource.open();
+
+            try {
+                SnapshotUpdateNotificationDTO update = events.poll(1, TimeUnit.SECONDS);
+                assertNotNull(update);
+                assertEquals(0, update.arriving().size());
+                assertEquals(0, update.modified().size());
+                assertEquals(0, update.departing().size());
+
+                // Register the resource
+                int initialValue = 42;
+                GenericDto dto = utils.makeDto(PROVIDER, service, resource, initialValue, Integer.class);
+                push.pushUpdate(dto);
+
+                // Wait for the SSE event
+                update = events.poll(1, TimeUnit.SECONDS);
+                assertNotNull(update);
+                assertEquals(1, update.arriving().size());
+                assertEquals(0, update.modified().size());
+                assertEquals(0, update.departing().size());
+
+                assertTrue(update.arriving().containsKey(PROVIDER));
+                assertEquals(initialValue, update.arriving().get(PROVIDER).services.get(service).resources.get(resource).value);
+
+                // Update value
+                dto.value = initialValue + 10;
+                push.pushUpdate(dto);
+
+                // Wait for the SSE Event
+                update = events.poll(1, TimeUnit.SECONDS);
+                assertNotNull(update);
+                assertEquals(0, update.arriving().size());
+                assertEquals(1, update.modified().size());
+                assertEquals(0, update.departing().size());
+
+                assertTrue(update.modified().containsKey(PROVIDER));
+                assertEquals(initialValue + 10, update.modified().get(PROVIDER).services.get(service).resources.get(resource).value);
+            } finally {
+                sseSource.close();
+            }
+        }
+
+        /**
+         * Ensure that SSE is closed when the server expires the session
+         */
+        @Test
+        void sseExpireOnServiceSide(@InjectService JakartarsServiceRuntime runtime) throws Exception {
+
+            // Ensure that no session is present at start
+            final SensiNactSession defaultSession = sessionManager.getDefaultSession(USER);
+            for (String sessionId : sessionManager.getSessionIds(USER)) {
+                SensiNactSession session = sessionManager.getSession(USER, sessionId);
+                if (session.getSessionId() != defaultSession.getSessionId()) {
+                    session.expire();
+                }
+            }
+            assertEquals(List.of(defaultSession.getSessionId()), sessionManager.getSessionIds(USER));
+
+            final String service = "new";
+            final String resource = "new-resource";
+            final String filter = "(&(PROVIDER=%s)(%s.%s=*)".formatted(PROVIDER, service, resource);
+
+            // Subscribe to a non-existent resource
+            final Client client = clientBuilder.connectTimeout(3, TimeUnit.SECONDS).register(JacksonJsonProvider.class)
+                    .build();
+            final SseEventSource sseSource = sseClient
+                    .newSource(client.target("http://localhost:8185/sensinact/").path("snapshot").path("subscribe")
+                            .queryParam("filter", filter).queryParam("filterLanguage", "ldap"));
+
+            final BlockingArrayQueue<Instant> expirationEvent = new BlockingArrayQueue<>();
+            sseSource.register(ise -> {
+                final String comment = ise.getComment();
+                if ("session-expired".equals(comment)) {
+                    expirationEvent.add(Instant.now());
+                }
+            }, Throwable::printStackTrace, () -> System.out.println("SSE Closed"));
+            sseSource.open();
+
+            try {
+                // Wait a bit to ensure the session is up
+                Thread.sleep(100);
+
+                // Look for the session
+                SensiNactSession sseSession = null;
+                for (String sessionId : sessionManager.getSessionIds(USER)) {
+                    SensiNactSession session = sessionManager.getSession(USER, sessionId);
+                    if (session != defaultSession && !sessionId.equals(defaultSession.getSessionId())) {
+                        sseSession = session;
+                        break;
+                    }
+                }
+                assertNotNull(sseSession, "SSE session not found");
+
+                // Wait for session to pass first expiry check
+                Instant expiration = expirationEvent.poll(SESSION_EXPIRY_SECONDS + SESSION_ACTIVITY_INTERVAL_SECONDS + 1,
+                        TimeUnit.SECONDS);
+                assertNull(expiration, "Session expired too early");
+
+                // Expire the session on the server side
+                final Instant closingTime = Instant.now();
+                sseSession.expire();
+
+                // Expiration should be received quickly
+                expiration = expirationEvent.poll(500, TimeUnit.MILLISECONDS);
+                assertNotNull(expiration, "Session expired event not received");
+                assertFalse(expiration.isBefore(closingTime), "Session expired too early");
+            } finally {
+                if (sseSource.isOpen()) {
+                    sseSource.close();
+                }
             }
         }
     }


### PR DESCRIPTION
This commit adds a REST endpoint for snapshot notifications. This is able to reuse the work already done for websockets, and only requires minor internal changes to support.