### PR TITLE
Ensure that we respond properly to snapshot requests with multiple filters

### DIFF
--- a/northbound/query-handler-impl/src/main/java/org/eclipse/sensinact/northbound/query/impl/QueryHandler.java
+++ b/northbound/query-handler-impl/src/main/java/org/eclipse/sensinact/northbound/query/impl/QueryHandler.java
@@ -12,6 +12,7 @@
 **********************************************************************/
 package org.eclipse.sensinact.northbound.query.impl;
 
+import static java.util.stream.Collectors.toMap;
 import static org.eclipse.sensinact.core.twin.SensinactDigitalTwin.SnapshotOption.INCLUDE_LINKED_PROVIDERS_FULL;
 import static org.eclipse.sensinact.core.twin.SensinactDigitalTwin.SnapshotOption.INCLUDE_LINKED_PROVIDER_IDS;
 import static org.eclipse.sensinact.northbound.query.dto.query.QuerySnapshotDTO.SnapshotLinkOption.ID_ONLY;
@@ -467,13 +468,9 @@ public class QueryHandler implements IQueryHandler {
         result.uri = "/";
         result.statusCode = 200;
 
-        for (var filter : query.filter) {
-            ICriterion criterion = resourceSelectorFilterFactory.parseResourceSelector(filter);
-            for (var providerSnapshot : executeFilter(userSession, criterion, query.linkOptions)) {
-                result.providers.computeIfAbsent(providerSnapshot.getName(),
-                        x -> toSnapshotProviderDTO(providerSnapshot, query.linkOptions, query.includeMetadata));
-            }
-        }
+        ICriterion criterion = resourceSelectorFilterFactory.parseResourceSelector(query.filter.stream());
+        result.providers = executeFilter(userSession, criterion, query.linkOptions).stream()
+            .collect(toMap(ps -> ps.getName(), ps -> toSnapshotProviderDTO(ps, query.linkOptions, query.includeMetadata)));
 
         return result;
     }

--- a/northbound/rest/src/test/java/org/eclipse/sensinact/northbound/rest/integration/ResourceSnapshotTest.java
+++ b/northbound/rest/src/test/java/org/eclipse/sensinact/northbound/rest/integration/ResourceSnapshotTest.java
@@ -122,6 +122,47 @@ public class ResourceSnapshotTest {
         assertEquals("V1", resourceDTO.value);
     }
 
+    /**
+     * Get the resource value
+     */
+    @Test
+    void multipleFilters() throws Exception {
+        // Register the resources
+        GenericDto dto = utils.makeDto("M1", "P1", "S1", "R1", "V1", String.class);
+        push.pushUpdate(dto).getValue();
+        dto = utils.makeDto("M1", "P1", "S2", "R2", "V2", String.class);
+        push.pushUpdate(dto).getValue();
+
+        List<ResourceSelector> request = new ArrayList<>();
+        ResourceSelector rs = new CompactResourceSelector(null, null, new Selection("P1"),
+                new Selection("S1"), new Selection("R1"), List.of(), List.of()).toResourceSelector();
+        request.add(rs);
+        rs = new CompactResourceSelector(null, null, new Selection("P1"),
+                new Selection("S2"), new Selection("R2"), List.of(), List.of()).toResourceSelector();
+        request.add(rs);
+        ResponseSnapshotDTO response = utils.queryJson("snapshot", request, ResponseSnapshotDTO.class);
+
+        assertEquals(1, response.providers.size());
+        SnapshotProviderDTO providerDTO = response.providers.get("P1");
+        assertEquals("P1", providerDTO.name);
+        assertEquals("M1", providerDTO.modelName);
+        assertEquals(2, providerDTO.services.size());
+        SnapshotServiceDTO serviceDTO = providerDTO.services.get("S1");
+        assertEquals("S1", serviceDTO.name);
+        assertEquals(1, serviceDTO.resources.size());
+        SnapshotResourceDTO resourceDTO = serviceDTO.resources.get("R1");
+        assertEquals("R1", resourceDTO.name);
+        assertEquals("java.lang.String", resourceDTO.type);
+        assertEquals("V1", resourceDTO.value);
+        serviceDTO = providerDTO.services.get("S2");
+        assertEquals("S2", serviceDTO.name);
+        assertEquals(1, serviceDTO.resources.size());
+        resourceDTO = serviceDTO.resources.get("R2");
+        assertEquals("R2", resourceDTO.name);
+        assertEquals("java.lang.String", resourceDTO.type);
+        assertEquals("V2", resourceDTO.value);
+    }
+
     @Test
     void setProvider() throws Exception {
         // Set a provider


### PR DESCRIPTION
When requesting a snapshot with multiple filters the results were not properly merged, leading to results from later filters being lost. This can be easily fixed by merging the filters into a single filter. This has the added benefit of making the snapshots atomic, as well as reducing the number of queries made and therefore the load on the gateway.