### PR TITLE
Escape notification topics

### DIFF
--- a/core/api/src/main/java/org/eclipse/sensinact/core/notification/LifecycleNotification.java
+++ b/core/api/src/main/java/org/eclipse/sensinact/core/notification/LifecycleNotification.java
@@ -40,7 +40,7 @@ public record LifecycleNotification(String modelPackageUri, String model, String
             Objects.requireNonNull(resource);
         }
 
-        return "LIFECYCLE/".concat(String.format(status.template, model, provider, service, resource));
+        return TopicUtils.escapeTopic("LIFECYCLE/".concat(String.format(status.template, model, provider, service, resource)));
     }
 
     public enum Status {

--- a/core/api/src/main/java/org/eclipse/sensinact/core/notification/LinkedProviderNotification.java
+++ b/core/api/src/main/java/org/eclipse/sensinact/core/notification/LinkedProviderNotification.java
@@ -36,7 +36,7 @@ public record LinkedProviderNotification(String modelPackageUri, String model, S
         Objects.requireNonNull(model);
         Objects.requireNonNull(provider);
 
-        return "LINKED/".concat(String.format("%s/%s", model, provider));
+        return TopicUtils.escapeTopic("LINKED/".concat(String.format("%s/%s", model, provider)));
     }
 
     @Override

--- a/core/api/src/main/java/org/eclipse/sensinact/core/notification/ResourceActionNotification.java
+++ b/core/api/src/main/java/org/eclipse/sensinact/core/notification/ResourceActionNotification.java
@@ -31,7 +31,7 @@ public record ResourceActionNotification(String modelPackageUri, String model, S
         Objects.requireNonNull(provider);
         Objects.requireNonNull(service);
         Objects.requireNonNull(resource);
-        return String.format("ACTION/%s/%s/%s/%s", model, provider, service, resource);
+        return TopicUtils.escapeTopic(String.format("ACTION/%s/%s/%s/%s", model, provider, service, resource));
     }
 
 }

--- a/core/api/src/main/java/org/eclipse/sensinact/core/notification/ResourceDataNotification.java
+++ b/core/api/src/main/java/org/eclipse/sensinact/core/notification/ResourceDataNotification.java
@@ -33,7 +33,7 @@ public record ResourceDataNotification(String modelPackageUri, String model, Str
         Objects.requireNonNull(provider);
         Objects.requireNonNull(service);
         Objects.requireNonNull(resource);
-        return String.format("DATA/%s/%s/%s/%s", model, provider, service, resource);
+        return TopicUtils.escapeTopic(String.format("DATA/%s/%s/%s/%s", model, provider, service, resource));
     }
 
 }

--- a/core/api/src/main/java/org/eclipse/sensinact/core/notification/ResourceMetaDataNotification.java
+++ b/core/api/src/main/java/org/eclipse/sensinact/core/notification/ResourceMetaDataNotification.java
@@ -34,7 +34,7 @@ public record ResourceMetaDataNotification(String modelPackageUri, String model,
         Objects.requireNonNull(provider);
         Objects.requireNonNull(service);
         Objects.requireNonNull(resource);
-        return String.format("METADATA/%s/%s/%s/%s", model, provider, service, resource);
+        return TopicUtils.escapeTopic(String.format("METADATA/%s/%s/%s/%s", model, provider, service, resource));
     }
 
 }

--- a/core/api/src/main/java/org/eclipse/sensinact/core/notification/TopicUtils.java
+++ b/core/api/src/main/java/org/eclipse/sensinact/core/notification/TopicUtils.java
@@ -1,0 +1,138 @@
+/*********************************************************************
+* Copyright (c) 2026 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   Kentyou - initial implementation
+**********************************************************************/
+package org.eclipse.sensinact.core.notification;
+
+import java.util.Arrays;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * Utility methods to manipulate the topic of a notification
+ */
+public class TopicUtils {
+
+    /**
+     * Escapes the given topic to be used as a topic in the typed event bus
+     *
+     * @param inputTopic the topic to escape
+     * @return the escaped topic
+     */
+    public static String escapeTopic(final String inputTopic) {
+        if (inputTopic == null || inputTopic.isEmpty()) {
+            // Pass through
+            return inputTopic;
+        }
+
+        return Arrays.stream(inputTopic.split("/")).map(topicPart -> escapeTopicPart(topicPart, false))
+                .collect(Collectors.joining("/"));
+    }
+
+    /**
+     * Unescapes the given topic to be used as a topic in the typed event bus
+     *
+     * @param escapedTopic the topic to unescape
+     * @return the unescaped topic
+     */
+    public static String unescapeTopic(final String escapedTopic) {
+        return Arrays.stream(escapedTopic.split("/")).map(TopicUtils::unescapeTopicPart)
+                .collect(Collectors.joining("/"));
+    }
+
+    /**
+     * Escapes the given topic filter to be used as a topic filter in the typed
+     * event bus
+     *
+     * @param inputTopicFilter the topic filter to escape
+     * @return the escaped topic filter
+     */
+    public static String escapeTopicFilter(final String inputTopicFilter) {
+        return Arrays.stream(inputTopicFilter.split("/")).map(topicPart -> escapeTopicPart(topicPart, true))
+                .collect(Collectors.joining("/"));
+    }
+
+    /**
+     * Unescapes the given topic filter to be used as a topic filter in the typed
+     * event bus
+     *
+     * @param escapedTopicFilter the topic filter to unescape
+     * @return the unescaped topic filter
+     */
+    public static String unescapeTopicFilter(final String escapedTopicFilter) {
+        return Arrays.stream(escapedTopicFilter.split("/")).map(TopicUtils::unescapeTopicPart)
+                .collect(Collectors.joining("/"));
+    }
+
+    /**
+     * Escapes a topic part by replacing invalid characters with their Unicode escape sequences
+     *
+     * @param topicPart the topic part to escape
+     * @param allowWildcards whether to allow wildcard characters
+     * @return the escaped topic part
+     */
+    private static String escapeTopicPart(final String topicPart, final boolean allowWildcards) {
+        return topicPart.chars().mapToObj(c -> {
+            if (c != '$'
+                    && (c == '-' || Character.isJavaIdentifierPart(c) || (allowWildcards && (c == '*' || c == '+')))) {
+                // Valid character other than '$', return as is
+                return Character.toString(c);
+            } else {
+                // Escape the character as a Unicode escape sequence
+                return String.format("$%04x", c);
+            }
+        }).collect(Collectors.joining());
+    }
+
+    /**
+     * Unescapes a topic part by replacing the escape sequences with the original characters
+     *
+     * @param escapedTopicPart the topic part to unescape
+     * @return the unescaped topic part
+     */
+    private static String unescapeTopicPart(final String escapedTopicPart) {
+        final StringBuilder unescaped = new StringBuilder(escapedTopicPart.length());
+
+        final Pattern escapePattern = Pattern.compile("\\$([a-fA-F0-9]{4})");
+        final Matcher matcher = escapePattern.matcher(escapedTopicPart);
+
+        if(matcher.find()) {
+            int lastEnd = 0;
+            do {
+                if(matcher.start() > lastEnd) {
+                    // Append the text before the escape sequence
+                    unescaped.append(escapedTopicPart.subSequence(lastEnd, matcher.start()));
+                }
+
+                lastEnd = matcher.end();
+
+                // Parse the block
+                String hex = matcher.group(1);
+                try {
+                    int codePoint = Integer.parseInt(hex, 16);
+                    unescaped.append((char) codePoint);
+                } catch (NumberFormatException e) {
+                    // Not a valid escape sequence, append the original text
+                    unescaped.append(matcher.group());
+                }
+            } while (matcher.find());
+
+            // Append the remaining text after the last escape sequence
+            unescaped.append(escapedTopicPart.substring(lastEnd));
+        } else {
+            // No escape sequences found, return the original string
+            return escapedTopicPart;
+        }
+
+        return unescaped.toString();
+    }
+}

--- a/core/api/src/test/java/org/eclipse/sensinact/core/notification/TopicUtilsTest.java
+++ b/core/api/src/test/java/org/eclipse/sensinact/core/notification/TopicUtilsTest.java
@@ -1,0 +1,103 @@
+/*********************************************************************
+* Copyright (c) 2026 Contributors to the Eclipse Foundation.
+*
+* This program and the accompanying materials are made
+* available under the terms of the Eclipse Public License 2.0
+* which is available at https://www.eclipse.org/legal/epl-2.0/
+*
+* SPDX-License-Identifier: EPL-2.0
+*
+* Contributors:
+*   Kentyou - initial implementation
+**********************************************************************/
+package org.eclipse.sensinact.core.notification;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class TopicUtilsTest {
+
+    @Test
+    void testEscapeTopic() {
+        // Test that normal topics are not changed
+        String topic = "a/b/c";
+        assertEquals(topic, TopicUtils.escapeTopic(topic));
+        assertEquals(topic, TopicUtils.unescapeTopic(topic));
+
+        // Test '-' (not escaped) and wildcard characters (escaped)
+        topic = "a/b-c/d+e/f*g";
+        assertEquals("a/b-c/d$002be/f$002ag", TopicUtils.escapeTopic(topic));
+        assertEquals(topic, TopicUtils.unescapeTopic(TopicUtils.escapeTopic(topic)));
+
+        // Test that topics with special characters are escaped
+        topic = "a/$b/c/d~e";
+        assertEquals("a/$0024b/c/d$007ee", TopicUtils.escapeTopic(topic));
+        assertEquals(topic, TopicUtils.unescapeTopic(TopicUtils.escapeTopic(topic)));
+
+        // Test topics with UTF-32 characters
+        topic = "a/𐍈/c";
+        assertEquals("a/$d800$df48/c", TopicUtils.escapeTopic(topic));
+        assertEquals(topic, TopicUtils.unescapeTopic(TopicUtils.escapeTopic(topic)));
+
+        // Test URL encoding
+        topic = "http://example.com/resource";
+        assertEquals("http$003a//example$002ecom/resource", TopicUtils.escapeTopic(topic));
+        assertEquals(topic, TopicUtils.unescapeTopic(TopicUtils.escapeTopic(topic)));
+    }
+
+    @Test
+    void testEscapeTopicFilter() {
+        // Test that normal topics are not changed
+        String topicFilter = "a/b/c";
+        assertEquals(topicFilter, TopicUtils.escapeTopicFilter(topicFilter));
+        assertEquals(topicFilter, TopicUtils.unescapeTopicFilter(topicFilter));
+
+        // Test '-' and wildcard characters
+        topicFilter = "a/b-c/+/*";
+        assertEquals(topicFilter, TopicUtils.escapeTopicFilter(topicFilter));
+        assertEquals(topicFilter, TopicUtils.unescapeTopicFilter(TopicUtils.escapeTopicFilter(topicFilter)));
+
+        // ... even if the topic is invalid
+        topicFilter = "a/b-c/d+e/f*g";
+        assertEquals(topicFilter, TopicUtils.escapeTopicFilter(topicFilter));
+        assertEquals(topicFilter, TopicUtils.unescapeTopicFilter(TopicUtils.escapeTopicFilter(topicFilter)));
+
+        // Test that topics with special characters are escaped
+        topicFilter = "a/$b/c/d~e";
+        assertEquals("a/$0024b/c/d$007ee", TopicUtils.escapeTopicFilter(topicFilter));
+        assertEquals(topicFilter, TopicUtils.unescapeTopicFilter(TopicUtils.escapeTopicFilter(topicFilter)));
+
+        // Test topics with UTF-32 characters
+        topicFilter = "a/𐍈/c";
+        assertEquals("a/$d800$df48/c", TopicUtils.escapeTopicFilter(topicFilter));
+        assertEquals(topicFilter, TopicUtils.unescapeTopicFilter(TopicUtils.escapeTopicFilter(topicFilter)));
+
+        // Test URL encoding
+        topicFilter = "http://example.com/resource";
+        assertEquals("http$003a//example$002ecom/resource", TopicUtils.escapeTopicFilter(topicFilter));
+        assertEquals(topicFilter, TopicUtils.unescapeTopicFilter(TopicUtils.escapeTopicFilter(topicFilter)));
+    }
+
+    @Test
+    void testNestedEscapeTopic() {
+        String topic = "a/𐍈/+/c";
+        String escapedTopic = TopicUtils.escapeTopic(topic);
+        assertEquals("a/$d800$df48/$002b/c", escapedTopic);
+        String nestedEscapedTopic = TopicUtils.escapeTopic(escapedTopic);
+        assertEquals("a/$0024d800$0024df48/$0024002b/c", nestedEscapedTopic);
+        assertEquals(escapedTopic, TopicUtils.unescapeTopic(nestedEscapedTopic));
+        assertEquals(topic, TopicUtils.unescapeTopic(escapedTopic));
+    }
+
+    @Test
+    void testNestedEscapeTopicFilter() {
+        String topicFilter = "a/𐍈/+/c";
+        String escapedTopicFilter = TopicUtils.escapeTopicFilter(topicFilter);
+        assertEquals("a/$d800$df48/+/c", escapedTopicFilter);
+        String nestedEscapedTopicFilter = TopicUtils.escapeTopicFilter(escapedTopicFilter);
+        assertEquals("a/$0024d800$0024df48/+/c", nestedEscapedTopicFilter);
+        assertEquals(escapedTopicFilter, TopicUtils.unescapeTopicFilter(nestedEscapedTopicFilter));
+        assertEquals(topicFilter, TopicUtils.unescapeTopicFilter(escapedTopicFilter));
+    }
+}

--- a/northbound/session/session-impl/src/main/java/org/eclipse/sensinact/northbound/session/impl/AbstractSensinactSessionEventManager.java
+++ b/northbound/session/session-impl/src/main/java/org/eclipse/sensinact/northbound/session/impl/AbstractSensinactSessionEventManager.java
@@ -97,7 +97,7 @@ public abstract class AbstractSensinactSessionEventManager
         if(event instanceof ResourceDataNotification rdn) {
             notifyData(topic, rdn);
         } else if (event instanceof ResourceMetaDataNotification rmn) {
-            notifyMetdata(topic, rmn);
+            notifyMetadata(topic, rmn);
         } else if (event instanceof LifecycleNotification ln) {
             notifyLifecycle(topic, ln);
         } else if (event instanceof ResourceActionNotification ran) {
@@ -111,7 +111,7 @@ public abstract class AbstractSensinactSessionEventManager
 
     protected abstract void notifyData(String topic, ResourceDataNotification notification);
 
-    protected abstract void notifyMetdata(String topic, ResourceMetaDataNotification notification);
+    protected abstract void notifyMetadata(String topic, ResourceMetaDataNotification notification);
 
     protected abstract void notifyAction(String topic, ResourceActionNotification notification);
 }

--- a/northbound/session/session-impl/src/main/java/org/eclipse/sensinact/northbound/session/impl/AbstractSensinactSessionEventManager.java
+++ b/northbound/session/session-impl/src/main/java/org/eclipse/sensinact/northbound/session/impl/AbstractSensinactSessionEventManager.java
@@ -17,6 +17,7 @@ import static org.osgi.service.typedevent.TypedEventConstants.TYPED_EVENT_TOPICS
 import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -26,6 +27,7 @@ import org.eclipse.sensinact.core.notification.ResourceActionNotification;
 import org.eclipse.sensinact.core.notification.ResourceDataNotification;
 import org.eclipse.sensinact.core.notification.ResourceMetaDataNotification;
 import org.eclipse.sensinact.core.notification.ResourceNotification;
+import org.eclipse.sensinact.core.notification.TopicUtils;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.typedevent.TypedEventHandler;
@@ -59,17 +61,21 @@ public abstract class AbstractSensinactSessionEventManager
      * @param context
      */
     public void register(BundleContext context) {
-        if(!state.compareAndSet(0, 1)) {
+        if (!state.compareAndSet(0, 1)) {
             throw new IllegalStateException("This listener has already been registered");
         }
         List<String> registeredTopics = getRegisteredTopics();
-        if(registeredTopics.isEmpty()) {
+        if (registeredTopics == null || registeredTopics.isEmpty()) {
             throw new IllegalArgumentException("No topics are registered");
         }
+
+        List<String> filteredTopics = registeredTopics.stream().filter(Objects::nonNull)
+                .map(TopicUtils::escapeTopicFilter).toList();
+
         registration.set(
                 context.registerService(TypedEventHandler.class, this,
-                        new Hashtable<>(Map.of(TYPED_EVENT_TOPICS, registeredTopics))));
-        if(state.get() != 1) {
+                        new Hashtable<>(Map.of(TYPED_EVENT_TOPICS, filteredTopics))));
+        if (state.get() != 1) {
             destroy();
         }
     }

--- a/northbound/session/session-impl/src/main/java/org/eclipse/sensinact/northbound/session/impl/SensinactSessionEventListener.java
+++ b/northbound/session/session-impl/src/main/java/org/eclipse/sensinact/northbound/session/impl/SensinactSessionEventListener.java
@@ -29,7 +29,6 @@ import org.eclipse.sensinact.core.notification.ResourceActionNotification;
 import org.eclipse.sensinact.core.notification.ResourceDataNotification;
 import org.eclipse.sensinact.core.notification.ResourceMetaDataNotification;
 import org.eclipse.sensinact.core.notification.ResourceNotification;
-import org.osgi.framework.BundleContext;
 import org.osgi.service.typedevent.TypedEventHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -128,7 +127,7 @@ public class SensinactSessionEventListener extends AbstractSensinactSessionEvent
         dataListener.notify(topic, notification);
     }
 
-    protected void notifyMetdata(String topic, ResourceMetaDataNotification notification) {
+    protected void notifyMetadata(String topic, ResourceMetaDataNotification notification) {
         if(!authorizer.hasResourcePermission(READ, notification.modelPackageUri(), notification.model(), notification.provider(), notification.service(), notification.resource())) {
             return;
         }

--- a/northbound/session/session-impl/src/main/java/org/eclipse/sensinact/northbound/session/impl/SensinactSessionSnapshotListener.java
+++ b/northbound/session/session-impl/src/main/java/org/eclipse/sensinact/northbound/session/impl/SensinactSessionSnapshotListener.java
@@ -436,7 +436,7 @@ public class SensinactSessionSnapshotListener extends AbstractSensinactSessionEv
         return wanted == true ? State.OUTDATED : State.SKIP;
     }
 
-    protected void notifyMetdata(String topic, ResourceMetaDataNotification rmn) {
+    protected void notifyMetadata(String topic, ResourceMetaDataNotification rmn) {
         if(!authorizer.hasResourcePermission(READ, rmn.modelPackageUri(), rmn.model(), rmn.provider(), rmn.service(), rmn.resource())) {
             return;
         }

--- a/northbound/session/session-impl/src/test/java/org/eclipse/sensinact/northbound/session/integration/SessionSubscribeTest.java
+++ b/northbound/session/session-impl/src/test/java/org/eclipse/sensinact/northbound/session/integration/SessionSubscribeTest.java
@@ -396,6 +396,17 @@ public class SessionSubscribeTest {
                 assertEquals(newValue, notification.newValue());
             } finally {
                 session.removeListener(subId);
+
+                thread.execute(new AbstractTwinCommand<Void>() {
+                    @Override
+                    protected Promise<Void> call(SensinactDigitalTwin twin, PromiseFactory pf) {
+                        SensinactProvider sp = twin.getProvider(providerName);
+                        if(sp != null) {
+                            sp.delete();
+                        }
+                        return pf.resolved(null);
+                    }
+                }).getValue();
             }
         }
     }

--- a/northbound/session/session-impl/src/test/java/org/eclipse/sensinact/northbound/session/integration/SessionSubscribeTest.java
+++ b/northbound/session/session-impl/src/test/java/org/eclipse/sensinact/northbound/session/integration/SessionSubscribeTest.java
@@ -364,7 +364,10 @@ public class SessionSubscribeTest {
 
     @Test
     void subscribeSpecialCharactersTopic() throws Exception {
+
+        SensiNactSession session = sessionManager.getDefaultSession(BOB);
         Random random = new Random();
+
         for (String providerName : List.of(
                 "some~provider",
                 "some#other$provider",
@@ -376,10 +379,9 @@ public class SessionSubscribeTest {
                 "постачальник",
                 "éà@()/:-?øþæ€ł🔟")) {
             BlockingQueue<ResourceDataNotification> queue = new ArrayBlockingQueue<>(32);
-            SensiNactSession session = sessionManager.getDefaultSession(BOB);
             String subId = session.addListener(List.of(MODEL + "/" + providerName + "/*"), (t, e) -> queue.offer(e),
                     null, null, null);
-            assertNotNull(subId);
+            assertNotNull(subId, "No subscription created for provider " + providerName);
 
             try {
                 int newValue = random.nextInt(32000);
@@ -387,8 +389,8 @@ public class SessionSubscribeTest {
 
                 ResourceDataNotification notification;
                 do {
-                    notification = queue.poll(1, TimeUnit.SECONDS);
-                    assertNotNull(notification);
+                    notification = queue.poll(5, TimeUnit.SECONDS);
+                    assertNotNull(notification, "No notification received for provider " + providerName);
                     assertEquals(providerName, notification.provider());
                 } while (!RESOURCE.equals(notification.resource()));
                 assertEquals(SERVICE, notification.service());
@@ -401,7 +403,7 @@ public class SessionSubscribeTest {
                     @Override
                     protected Promise<Void> call(SensinactDigitalTwin twin, PromiseFactory pf) {
                         SensinactProvider sp = twin.getProvider(providerName);
-                        if(sp != null) {
+                        if (sp != null) {
                             sp.delete();
                         }
                         return pf.resolved(null);

--- a/northbound/session/session-impl/src/test/java/org/eclipse/sensinact/northbound/session/integration/SessionSubscribeTest.java
+++ b/northbound/session/session-impl/src/test/java/org/eclipse/sensinact/northbound/session/integration/SessionSubscribeTest.java
@@ -18,6 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.List;
+import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
@@ -359,5 +360,43 @@ public class SessionSubscribeTest {
         // New match not visible either
         pushDto(beforeNoMatch, VALUE_2);
         assertNull(queue.poll(1, TimeUnit.SECONDS));
+    }
+
+    @Test
+    void subscribeSpecialCharactersTopic() throws Exception {
+        Random random = new Random();
+        for (String providerName : List.of(
+                "some~provider",
+                "some#other$provider",
+                "πάροχος",
+                "sağlayıcı",
+                "प्रदाता",
+                "المزود",
+                "供應商",
+                "постачальник",
+                "éà@()/:-?øþæ€ł🔟")) {
+            BlockingQueue<ResourceDataNotification> queue = new ArrayBlockingQueue<>(32);
+            SensiNactSession session = sessionManager.getDefaultSession(BOB);
+            String subId = session.addListener(List.of(MODEL + "/" + providerName + "/*"), (t, e) -> queue.offer(e),
+                    null, null, null);
+            assertNotNull(subId);
+
+            try {
+                int newValue = random.nextInt(32000);
+                pushDto(providerName, newValue);
+
+                ResourceDataNotification notification;
+                do {
+                    notification = queue.poll(1, TimeUnit.SECONDS);
+                    assertNotNull(notification);
+                    assertEquals(providerName, notification.provider());
+                } while (!RESOURCE.equals(notification.resource()));
+                assertEquals(SERVICE, notification.service());
+                assertNull(notification.oldValue(), "Got an old value");
+                assertEquals(newValue, notification.newValue());
+            } finally {
+                session.removeListener(subId);
+            }
+        }
     }
 }

--- a/southbound/history/timescale-provider/src/main/java/org/eclipse/sensinact/gateway/southbound/history/timescale/TimescaleHistoricalStore.java
+++ b/southbound/history/timescale-provider/src/main/java/org/eclipse/sensinact/gateway/southbound/history/timescale/TimescaleHistoricalStore.java
@@ -18,14 +18,17 @@ import java.sql.Connection;
 import java.sql.Statement;
 import java.util.Arrays;
 import java.util.Hashtable;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.sensinact.core.command.AbstractSensinactCommand;
 import org.eclipse.sensinact.core.command.AbstractTwinCommand;
 import org.eclipse.sensinact.core.command.GatewayThread;
 import org.eclipse.sensinact.core.model.SensinactModelManager;
+import org.eclipse.sensinact.core.notification.TopicUtils;
 import org.eclipse.sensinact.core.snapshot.ICriterion;
 import org.eclipse.sensinact.core.twin.SensinactDigitalTwin;
 import org.eclipse.sensinact.core.twin.SensinactProvider;
@@ -320,9 +323,14 @@ public class TimescaleHistoricalStore {
             if (logger.isDebugEnabled()) {
                 logger.debug("Registering listener for data update events");
             }
+
+            List<String> dataTopics = Optional.ofNullable(include.dataTopics())
+                    .map(l -> l.stream().filter(Objects::nonNull).map(TopicUtils::escapeTopicFilter).toList())
+                    .orElse(null);
+
             reg = ctx.registerService(TypedEventHandler.class,
                     new TimescaleDatabaseWorker(txControl, connection::get, include, exclude),
-                    new Hashtable<>(Map.of(TYPED_EVENT_TOPICS, include.dataTopics(), "sensiNact.whiteboard.resource",
+                    new Hashtable<>(Map.of(TYPED_EVENT_TOPICS, dataTopics, "sensiNact.whiteboard.resource",
                             true, "sensiNact.provider.name", config.provider())));
             synchronized (this) {
                 if (this.reg == null) {

--- a/southbound/rules/rules.impl/src/main/java/org/eclipse/sensinact/southbound/rules/impl/RuleProcessor.java
+++ b/southbound/rules/rules.impl/src/main/java/org/eclipse/sensinact/southbound/rules/impl/RuleProcessor.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -35,6 +36,7 @@ import org.eclipse.sensinact.core.metrics.IMetricTimer;
 import org.eclipse.sensinact.core.metrics.IMetricsManager;
 import org.eclipse.sensinact.core.model.SensinactModelManager;
 import org.eclipse.sensinact.core.notification.ResourceDataNotification;
+import org.eclipse.sensinact.core.notification.TopicUtils;
 import org.eclipse.sensinact.core.snapshot.ICriterion;
 import org.eclipse.sensinact.core.snapshot.ProviderSnapshot;
 import org.eclipse.sensinact.core.snapshot.ResourceSnapshot;
@@ -98,8 +100,12 @@ public class RuleProcessor implements TypedEventHandler<ResourceDataNotification
         this.eventRejection = metrics.getMeter(sanitizedMetricPrefix + ".rejection");
         this.timerName = sanitizedMetricPrefix + ".execution";
 
+        List<String> dataTopics = Optional.ofNullable(criterion.dataTopics())
+                .map(l -> l.stream().filter(Objects::nonNull).map(TopicUtils::escapeTopicFilter).toList())
+                .orElse(null);
+
         reg = context.registerService(TypedEventHandler.class, this,
-                new Hashtable<>(Map.of(TypedEventConstants.TYPED_EVENT_TOPICS, criterion.dataTopics())));
+                new Hashtable<>(Map.of(TypedEventConstants.TYPED_EVENT_TOPICS, dataTopics)));
 
         updateSnapshot(1);
     }


### PR DESCRIPTION
This PR fixes notification delivery for providers whose names contain characters that are invalid in typed event bus topics.

The typed event bus specification only permits a limited set of characters in topic names, while sensiNact does not impose the same restrictions on provider, service, or resource names. As a result, some notifications were rejected because their generated topics contained unsupported characters.

This PR adds the escape of invalid topic characters before publishing. Unsupported characters, as well as the $ character itself, are now encoded as $xxxx, where xxxx is the character’s code point. UTF-32 characters are supported and are encoded as a pair in the form $xxxx$yyyy.

This PR also adds a test to verify that notifications for providers with such names are correctly delivered.