### PR TITLE
Update topic escaping rules and apply them automatically

### DIFF
--- a/core/api/src/main/java/org/eclipse/sensinact/core/notification/LifecycleNotification.java
+++ b/core/api/src/main/java/org/eclipse/sensinact/core/notification/LifecycleNotification.java
@@ -40,7 +40,9 @@ public record LifecycleNotification(String modelPackageUri, String model, String
             Objects.requireNonNull(resource);
         }
 
-        return TopicUtils.escapeTopic("LIFECYCLE/".concat(String.format(status.template, model, provider, service, resource)));
+        return String.format(status.template,
+                TopicUtils.escapeTopicPart(model, false), TopicUtils.escapeTopicPart(provider, false),
+                TopicUtils.escapeTopicPart(service, false), TopicUtils.escapeTopicPart(resource, false));
     }
 
     public enum Status {
@@ -54,7 +56,7 @@ public record LifecycleNotification(String modelPackageUri, String model, String
          * service names for initial services</li>
          * </ul>
          */
-        PROVIDER_CREATED("%s/%s"),
+        PROVIDER_CREATED("LIFECYCLE/%s/%s"),
 
         /**
          * Provider deleted,
@@ -65,7 +67,7 @@ public record LifecycleNotification(String modelPackageUri, String model, String
          * <li>{@link LifecycleNotification#initialValue} will be null</li>
          * </ul>
          */
-        PROVIDER_DELETED("%s/%s"),
+        PROVIDER_DELETED("LIFECYCLE/%s/%s"),
 
         /**
          * Service created,
@@ -76,7 +78,7 @@ public record LifecycleNotification(String modelPackageUri, String model, String
          * service names for initial resources</li>
          * </ul>
          */
-        SERVICE_CREATED("%s/%s/%s"),
+        SERVICE_CREATED("LIFECYCLE/%s/%s/%s"),
 
         /**
          * Service deleted,
@@ -86,7 +88,7 @@ public record LifecycleNotification(String modelPackageUri, String model, String
          * <li>{@link LifecycleNotification#initialValue} will be null</li>
          * </ul>
          */
-        SERVICE_DELETED("%s/%s/%s"),
+        SERVICE_DELETED("LIFECYCLE/%s/%s/%s"),
 
         /**
          * Resource created,
@@ -96,7 +98,7 @@ public record LifecycleNotification(String modelPackageUri, String model, String
          * <li>{@link LifecycleNotification#initialValue} will be the initial value</li>
          * </ul>
          */
-        RESOURCE_CREATED("%s/%s/%s/%s"),
+        RESOURCE_CREATED("LIFECYCLE/%s/%s/%s/%s"),
 
         /**
          * Resource deleted,
@@ -105,7 +107,7 @@ public record LifecycleNotification(String modelPackageUri, String model, String
          * <li>{@link LifecycleNotification#initialValue} will be null</li>
          * </ul>
          */
-        RESOURCE_DELETED("%s/%s/%s/%s");
+        RESOURCE_DELETED("LIFECYCLE/%s/%s/%s/%s");
 
         private final String template;
 

--- a/core/api/src/main/java/org/eclipse/sensinact/core/notification/LinkedProviderNotification.java
+++ b/core/api/src/main/java/org/eclipse/sensinact/core/notification/LinkedProviderNotification.java
@@ -36,7 +36,8 @@ public record LinkedProviderNotification(String modelPackageUri, String model, S
         Objects.requireNonNull(model);
         Objects.requireNonNull(provider);
 
-        return TopicUtils.escapeTopic("LINKED/".concat(String.format("%s/%s", model, provider)));
+        return String.format("LINKED/%s/%s", TopicUtils.escapeTopicPart(model, false),
+                TopicUtils.escapeTopicPart(provider, false));
     }
 
     @Override

--- a/core/api/src/main/java/org/eclipse/sensinact/core/notification/ResourceActionNotification.java
+++ b/core/api/src/main/java/org/eclipse/sensinact/core/notification/ResourceActionNotification.java
@@ -31,7 +31,9 @@ public record ResourceActionNotification(String modelPackageUri, String model, S
         Objects.requireNonNull(provider);
         Objects.requireNonNull(service);
         Objects.requireNonNull(resource);
-        return TopicUtils.escapeTopic(String.format("ACTION/%s/%s/%s/%s", model, provider, service, resource));
+        return TopicUtils.escapeTopic(String.format("ACTION/%s/%s/%s/%s",
+                TopicUtils.escapeTopicPart(model, false), TopicUtils.escapeTopicPart(provider, false),
+                TopicUtils.escapeTopicPart(service, false), TopicUtils.escapeTopicPart(resource, false)));
     }
 
 }

--- a/core/api/src/main/java/org/eclipse/sensinact/core/notification/ResourceDataNotification.java
+++ b/core/api/src/main/java/org/eclipse/sensinact/core/notification/ResourceDataNotification.java
@@ -33,7 +33,9 @@ public record ResourceDataNotification(String modelPackageUri, String model, Str
         Objects.requireNonNull(provider);
         Objects.requireNonNull(service);
         Objects.requireNonNull(resource);
-        return TopicUtils.escapeTopic(String.format("DATA/%s/%s/%s/%s", model, provider, service, resource));
+        return String.format("DATA/%s/%s/%s/%s",
+                TopicUtils.escapeTopicPart(model, false), TopicUtils.escapeTopicPart(provider, false),
+                TopicUtils.escapeTopicPart(service, false), TopicUtils.escapeTopicPart(resource, false));
     }
 
 }

--- a/core/api/src/main/java/org/eclipse/sensinact/core/notification/ResourceMetaDataNotification.java
+++ b/core/api/src/main/java/org/eclipse/sensinact/core/notification/ResourceMetaDataNotification.java
@@ -34,7 +34,9 @@ public record ResourceMetaDataNotification(String modelPackageUri, String model,
         Objects.requireNonNull(provider);
         Objects.requireNonNull(service);
         Objects.requireNonNull(resource);
-        return TopicUtils.escapeTopic(String.format("METADATA/%s/%s/%s/%s", model, provider, service, resource));
+        return String.format("METADATA/%s/%s/%s/%s",
+                TopicUtils.escapeTopicPart(model, false), TopicUtils.escapeTopicPart(provider, false),
+                TopicUtils.escapeTopicPart(service, false), TopicUtils.escapeTopicPart(resource, false));
     }
 
 }

--- a/core/api/src/main/java/org/eclipse/sensinact/core/notification/TopicUtils.java
+++ b/core/api/src/main/java/org/eclipse/sensinact/core/notification/TopicUtils.java
@@ -13,8 +13,6 @@
 package org.eclipse.sensinact.core.notification;
 
 import java.util.Arrays;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
@@ -80,17 +78,53 @@ public class TopicUtils {
      * @param allowWildcards whether to allow wildcard characters
      * @return the escaped topic part
      */
-    private static String escapeTopicPart(final String topicPart, final boolean allowWildcards) {
-        return topicPart.chars().mapToObj(c -> {
-            if (c != '$'
-                    && (c == '-' || Character.isJavaIdentifierPart(c) || (allowWildcards && (c == '*' || c == '+')))) {
-                // Valid character other than '$', return as is
-                return Character.toString(c);
-            } else {
-                // Escape the character as a Unicode escape sequence
-                return String.format("$%04x", c);
+    public static CharSequence escapeTopicPart(final String topicPart, final boolean allowWildcards) {
+        if(topicPart == null || topicPart.isEmpty()) {
+            return topicPart;
+        }
+
+        StringBuilder sb = new StringBuilder(topicPart.length());
+
+        for(int i = 0; i < topicPart.length(); i++) {
+            int cp = topicPart.codePointAt(i);
+            switch(cp) {
+                case '$':
+                    // $ must be escaped
+                    sb.append("$0024");
+                    break;
+                case '*':
+                    sb.append(allowWildcards? "*" : "$002a");
+                    break;
+                case '+':
+                    sb.append(allowWildcards? "+" : "$002b");
+                    break;
+                case '-':
+                    // can pass through
+                    sb.append('-');
+                    break;
+                default:
+                    if(Character.isJavaIdentifierPart(cp)) {
+                        // permissable character
+                        sb.appendCodePoint(cp);
+                        // Step over the char we have already consumed
+                        if(!Character.isBmpCodePoint(cp)) {
+                            i++;
+                        }
+                    } else {
+                        // must be escaped
+                        if(Character.isBmpCodePoint(cp)) {
+                            sb.append(String.format("$%04x", cp));
+                        } else {
+                            char[] chars = Character.toChars(cp);
+                            sb.append(String.format("$%04x$%04x", (int)chars[0], (int)chars[1]));
+                            // Step over the char we have already consumed
+                            i++;
+                        }
+                    }
+                    break;
             }
-        }).collect(Collectors.joining());
+        }
+        return sb;
     }
 
     /**
@@ -99,40 +133,50 @@ public class TopicUtils {
      * @param escapedTopicPart the topic part to unescape
      * @return the unescaped topic part
      */
-    private static String unescapeTopicPart(final String escapedTopicPart) {
-        final StringBuilder unescaped = new StringBuilder(escapedTopicPart.length());
-
-        final Pattern escapePattern = Pattern.compile("\\$([a-fA-F0-9]{4})");
-        final Matcher matcher = escapePattern.matcher(escapedTopicPart);
-
-        if(matcher.find()) {
-            int lastEnd = 0;
-            do {
-                if(matcher.start() > lastEnd) {
-                    // Append the text before the escape sequence
-                    unescaped.append(escapedTopicPart.subSequence(lastEnd, matcher.start()));
-                }
-
-                lastEnd = matcher.end();
-
-                // Parse the block
-                String hex = matcher.group(1);
-                try {
-                    int codePoint = Integer.parseInt(hex, 16);
-                    unescaped.append((char) codePoint);
-                } catch (NumberFormatException e) {
-                    // Not a valid escape sequence, append the original text
-                    unescaped.append(matcher.group());
-                }
-            } while (matcher.find());
-
-            // Append the remaining text after the last escape sequence
-            unescaped.append(escapedTopicPart.substring(lastEnd));
-        } else {
-            // No escape sequences found, return the original string
+    public static CharSequence unescapeTopicPart(final String escapedTopicPart) {
+        if(escapedTopicPart == null || escapedTopicPart.isEmpty()) {
             return escapedTopicPart;
         }
 
-        return unescaped.toString();
+        int idx = escapedTopicPart.indexOf('$');
+        if(idx < 0) {
+            return escapedTopicPart;
+        } else {
+            final StringBuilder unescaped = new StringBuilder(escapedTopicPart.subSequence(0, idx));
+            for(int i = idx; i < escapedTopicPart.length(); i++) {
+                int codePoint = escapedTopicPart.codePointAt(i);
+                if(!Character.isBmpCodePoint(codePoint)) {
+                    // We have moved two character indexes in the string
+                    i++;
+                } else if(codePoint == '$') {
+                    if(escapedTopicPart.length() < i+5) {
+                        throw new IllegalArgumentException("Invalid escape sequence " + escapedTopicPart.substring(i)
+                            + " in segment " + escapedTopicPart);
+                    }
+                    try {
+                        int first = Integer.parseInt(escapedTopicPart.substring(i+1, i+5), 16);
+                        if(Character.isSurrogate((char)first)) {
+                            if(escapedTopicPart.length() < i+10 || escapedTopicPart.charAt(i+5) != '$') {
+                                throw new IllegalArgumentException("Invalid escape sequence " + escapedTopicPart.substring(i, i + 10)
+                                + " in segment " + escapedTopicPart);
+                            }
+                            int second = Integer.parseInt(escapedTopicPart.substring(i+6, i+10), 16);
+                            codePoint = Character.toCodePoint((char) first, (char) second);
+                            // We have moved 9 characters forward in the string
+                            i += 9;
+                        } else {
+                            codePoint = first;
+                            // we have moved four character indexes in the string
+                            i += 4;
+                        }
+                    } catch (NumberFormatException nfe) {
+                        throw new IllegalArgumentException("Invalid escape sequence " + escapedTopicPart.substring(i, i + 4)
+                            + " in segment " + escapedTopicPart);
+                    }
+                }
+                unescaped.appendCodePoint(codePoint);
+            }
+            return unescaped.toString();
+        }
     }
 }

--- a/core/api/src/main/java/org/eclipse/sensinact/core/snapshot/ICriterion.java
+++ b/core/api/src/main/java/org/eclipse/sensinact/core/snapshot/ICriterion.java
@@ -133,6 +133,9 @@ public interface ICriterion {
         };
     }
 
+    /**
+     * @return The (escaped) topic filter(s) that should be used when applying this filter.
+     */
     default List<String> dataTopics() {
         return List.of("DATA/*");
     }

--- a/core/api/src/test/java/org/eclipse/sensinact/core/notification/TopicUtilsTest.java
+++ b/core/api/src/test/java/org/eclipse/sensinact/core/notification/TopicUtilsTest.java
@@ -37,8 +37,11 @@ public class TopicUtilsTest {
 
         // Test topics with UTF-32 characters
         topic = "a/𐍈/c";
-        assertEquals("a/$d800$df48/c", TopicUtils.escapeTopic(topic));
+        assertEquals("a/𐍈/c", TopicUtils.escapeTopic(topic));
         assertEquals(topic, TopicUtils.unescapeTopic(TopicUtils.escapeTopic(topic)));
+        topic = "a/🙂/c";
+        assertEquals("a/$d83d$de42/c", TopicUtils.escapeTopic(topic));
+        assertEquals(topic, TopicUtils.unescapeTopicFilter(TopicUtils.escapeTopicFilter(topic)));
 
         // Test URL encoding
         topic = "http://example.com/resource";
@@ -70,7 +73,11 @@ public class TopicUtilsTest {
 
         // Test topics with UTF-32 characters
         topicFilter = "a/𐍈/c";
-        assertEquals("a/$d800$df48/c", TopicUtils.escapeTopicFilter(topicFilter));
+        assertEquals("a/𐍈/c", TopicUtils.escapeTopicFilter(topicFilter));
+        assertEquals(topicFilter, TopicUtils.unescapeTopicFilter(TopicUtils.escapeTopicFilter(topicFilter)));
+
+        topicFilter = "a/🙂/c";
+        assertEquals("a/$d83d$de42/c", TopicUtils.escapeTopicFilter(topicFilter));
         assertEquals(topicFilter, TopicUtils.unescapeTopicFilter(TopicUtils.escapeTopicFilter(topicFilter)));
 
         // Test URL encoding
@@ -81,22 +88,22 @@ public class TopicUtilsTest {
 
     @Test
     void testNestedEscapeTopic() {
-        String topic = "a/𐍈/+/c";
+        String topic = "a/𐍈/🙂/+/c";
         String escapedTopic = TopicUtils.escapeTopic(topic);
-        assertEquals("a/$d800$df48/$002b/c", escapedTopic);
+        assertEquals("a/𐍈/$d83d$de42/$002b/c", escapedTopic);
         String nestedEscapedTopic = TopicUtils.escapeTopic(escapedTopic);
-        assertEquals("a/$0024d800$0024df48/$0024002b/c", nestedEscapedTopic);
+        assertEquals("a/𐍈/$0024d83d$0024de42/$0024002b/c", nestedEscapedTopic);
         assertEquals(escapedTopic, TopicUtils.unescapeTopic(nestedEscapedTopic));
         assertEquals(topic, TopicUtils.unescapeTopic(escapedTopic));
     }
 
     @Test
     void testNestedEscapeTopicFilter() {
-        String topicFilter = "a/𐍈/+/c";
+        String topicFilter = "a/𐍈/🙂/+/c";
         String escapedTopicFilter = TopicUtils.escapeTopicFilter(topicFilter);
-        assertEquals("a/$d800$df48/+/c", escapedTopicFilter);
+        assertEquals("a/𐍈/$d83d$de42/+/c", escapedTopicFilter);
         String nestedEscapedTopicFilter = TopicUtils.escapeTopicFilter(escapedTopicFilter);
-        assertEquals("a/$0024d800$0024df48/+/c", nestedEscapedTopicFilter);
+        assertEquals("a/𐍈/$0024d83d$0024de42/+/c", nestedEscapedTopicFilter);
         assertEquals(escapedTopicFilter, TopicUtils.unescapeTopicFilter(nestedEscapedTopicFilter));
         assertEquals(topicFilter, TopicUtils.unescapeTopicFilter(escapedTopicFilter));
     }

--- a/filters/resource.selector.impl/src/main/java/org/eclipse/sensinact/filters/resource/selector/impl/ResourceSelectorCriterion.java
+++ b/filters/resource.selector.impl/src/main/java/org/eclipse/sensinact/filters/resource/selector/impl/ResourceSelectorCriterion.java
@@ -21,6 +21,7 @@ import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import org.eclipse.sensinact.core.notification.ResourceDataNotification;
+import org.eclipse.sensinact.core.notification.TopicUtils;
 import org.eclipse.sensinact.core.snapshot.ICriterion;
 import org.eclipse.sensinact.core.snapshot.ProviderSnapshot;
 import org.eclipse.sensinact.core.snapshot.ResourceSnapshot;
@@ -151,8 +152,8 @@ public class ResourceSelectorCriterion implements ICriterion {
         Set<String> found = new HashSet<String>();
         for(ProviderSelectionCriterion ps : providerSelections) {
             Set<String> locallyFound = new HashSet<String>();
-            String exactModel = ps.exactModel();
-            String exactProvider = ps.exactProvider();
+            CharSequence exactModel = TopicUtils.escapeTopicPart(ps.exactModel(), false);
+            CharSequence exactProvider = TopicUtils.escapeTopicPart(ps.exactProvider(), false);
             if(exactModel == null) {
                 if(allowSingleLevelWildcards) {
                     exactModel = "+";
@@ -173,8 +174,8 @@ public class ResourceSelectorCriterion implements ICriterion {
             }
 
             for(ResourceSelectionCriterion rsc : Stream.concat(ps.getResources().stream(), additionalResources.stream()).toList()) {
-                String exactService = rsc.exactService();
-                String exactResource = rsc.exactResource();
+                CharSequence exactService = TopicUtils.escapeTopicPart(rsc.exactService(), false);
+                CharSequence exactResource = TopicUtils.escapeTopicPart(rsc.exactResource(), false);
                 if(exactService == null) {
                     if(allowSingleLevelWildcards) {
                         exactService = "+";

--- a/filters/resource.selector/src/test/java/org/eclipse/sensinact/gateway/filters/resource/selector/api/JsonSerializationTests.java
+++ b/filters/resource.selector/src/test/java/org/eclipse/sensinact/gateway/filters/resource/selector/api/JsonSerializationTests.java
@@ -148,6 +148,29 @@ class JsonSerializationTests {
                     ValueSelectionMode.ANY_MATCH);
         }
 
+        @Test
+        void empty() throws StreamReadException, DatabindException, IOException {
+            // Totally empty behaves like a compact selector
+            ResourceSelector empty = mapper.readValue("{}", ResourceSelector.class);
+            // Must have a provider
+            assertEquals(1, empty.providers().size());
+
+            ProviderSelection ps = empty.providers().get(0);
+            assertNotNull(ps);
+
+            assertNull(ps.modelUri());
+            assertNull(ps.model());
+            assertNull(ps.provider());
+            assertEquals(List.of(), ps.location());
+            assertEquals(List.of(), ps.resources());
+
+            // Should select all resources
+            assertEquals(1, empty.resources().size());
+            assertNotNull(empty.resources().get(0));
+            assertNull(empty.resources().get(0).service());
+            assertNull(empty.resources().get(0).resource());
+            assertEquals(List.of(), empty.resources().get(0).value());
+        }
     }
 
     @Nested

--- a/northbound/query-handler-api/src/main/java/org/eclipse/sensinact/northbound/query/api/IQueryHandler.java
+++ b/northbound/query-handler-api/src/main/java/org/eclipse/sensinact/northbound/query/api/IQueryHandler.java
@@ -49,7 +49,9 @@ public interface IQueryHandler {
     ICriterion parseFilter(String filter, String filterLanguage) throws StatusException;
 
     /**
-     * Creates a {@link SnapshotProviderDTO} from the given {@link ProviderSnapshot}
+     * Creates a {@link SnapshotProviderDTO} from the given {@link ProviderSnapshot}.
+     * Does not query the gateway thread.
+     *
      * @param providerSnapshot
      * @param linkOptions
      * @param includeMetadata

--- a/northbound/session/session-api/src/main/java/org/eclipse/sensinact/northbound/session/SensiNactSession.java
+++ b/northbound/session/session-api/src/main/java/org/eclipse/sensinact/northbound/session/SensiNactSession.java
@@ -24,6 +24,7 @@ import org.eclipse.sensinact.core.notification.ClientActionListener;
 import org.eclipse.sensinact.core.notification.ClientDataListener;
 import org.eclipse.sensinact.core.notification.ClientLifecycleListener;
 import org.eclipse.sensinact.core.notification.ClientMetadataListener;
+import org.eclipse.sensinact.core.notification.TopicUtils;
 import org.eclipse.sensinact.core.push.DataUpdate;
 import org.eclipse.sensinact.core.snapshot.ICriterion;
 import org.eclipse.sensinact.core.snapshot.ProviderSnapshot;
@@ -84,15 +85,33 @@ public interface SensiNactSession {
     Map<String, List<String>> activeListeners();
 
     /**
-     *
-     * @param topics topic strings, omitting the initial segment (e.g. LIFECYCLE)
+     * Add a session event listener. This is equivalent to
+     * {@link #addListener(List, boolean, ClientDataListener, ClientMetadataListener, ClientLifecycleListener, ClientActionListener)}
+     * with {@code escapeTopics} set to {@code true}
+     * @param topics topic strings, omitting the initial segment (e.g. LIFECYCLE).
      * @param cdl    a listener, or null if data events are ignored
      * @param cml    a listener, or null if metadata events are ignored
      * @param cll    a listener, or null if lifecycle events are ignored
      * @param cal    a listener, or null if action events are ignored
      * @return a new registration identifier
      */
-    String addListener(List<String> topics, ClientDataListener cdl, ClientMetadataListener cml,
+    default String addListener(List<String> topics, ClientDataListener cdl, ClientMetadataListener cml,
+            ClientLifecycleListener cll, ClientActionListener cal) {
+        return addListener(topics, true, cdl, cml, cll, cal);
+    }
+
+    /**
+     * Add a session event listener.
+     * @param topics topic strings, omitting the initial segment (e.g. LIFECYCLE).
+     * @param escapeTopics if true then the topics will be escaped to remove unfriendly
+     * characters as per {@link TopicUtils#escapeTopicFilter(String)}
+     * @param cdl    a listener, or null if data events are ignored
+     * @param cml    a listener, or null if metadata events are ignored
+     * @param cll    a listener, or null if lifecycle events are ignored
+     * @param cal    a listener, or null if action events are ignored
+     * @return a new registration identifier
+     */
+    String addListener(List<String> topics, boolean escapeTopics, ClientDataListener cdl, ClientMetadataListener cml,
             ClientLifecycleListener cll, ClientActionListener cal);
 
 

--- a/northbound/session/session-impl/src/main/java/org/eclipse/sensinact/northbound/session/impl/AbstractSensinactSessionEventManager.java
+++ b/northbound/session/session-impl/src/main/java/org/eclipse/sensinact/northbound/session/impl/AbstractSensinactSessionEventManager.java
@@ -27,7 +27,6 @@ import org.eclipse.sensinact.core.notification.ResourceActionNotification;
 import org.eclipse.sensinact.core.notification.ResourceDataNotification;
 import org.eclipse.sensinact.core.notification.ResourceMetaDataNotification;
 import org.eclipse.sensinact.core.notification.ResourceNotification;
-import org.eclipse.sensinact.core.notification.TopicUtils;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.typedevent.TypedEventHandler;
@@ -70,7 +69,7 @@ public abstract class AbstractSensinactSessionEventManager
         }
 
         List<String> filteredTopics = registeredTopics.stream().filter(Objects::nonNull)
-                .map(TopicUtils::escapeTopicFilter).toList();
+                .toList();
 
         registration.set(
                 context.registerService(TypedEventHandler.class, this,

--- a/northbound/session/session-impl/src/main/java/org/eclipse/sensinact/northbound/session/impl/SensiNactSessionImpl.java
+++ b/northbound/session/session-impl/src/main/java/org/eclipse/sensinact/northbound/session/impl/SensiNactSessionImpl.java
@@ -155,10 +155,10 @@ public class SensiNactSessionImpl implements SensiNactSession {
     }
 
     @Override
-    public String addListener(List<String> topics, ClientDataListener cdl, ClientMetadataListener cml,
+    public String addListener(List<String> topics, boolean escapeTopics, ClientDataListener cdl, ClientMetadataListener cml,
             ClientLifecycleListener cll, ClientActionListener cal) {
         return doAddListener(subId -> new SensinactSessionEventListener(sessionId,
-                subId, topics, authorizer, cll, cdl, cml, cal));
+                subId, topics, escapeTopics, authorizer, cll, cdl, cml, cal));
     }
 
     private String doAddListener(Function<String, AbstractSensinactSessionEventManager> creator) {
@@ -189,9 +189,10 @@ public class SensiNactSessionImpl implements SensiNactSession {
             ssem.destroy();
             throw new IllegalStateException("The session is expired");
         } else {
-            // Asynchronously register to ensure that the session id can be returned
-            // while blocking calls in the listeners
-            promiseFactory.executor().execute(() -> ssem.register(context));
+            // Synchronously register to ensure that the session is immediately
+            // responsive to events. Note that callers may receive events before
+            // the id is returned and must handle this in a non-blocking fashion
+            ssem.register(context);
         }
         return subscriptionId;
     }

--- a/northbound/session/session-impl/src/main/java/org/eclipse/sensinact/northbound/session/impl/SensinactSessionEventListener.java
+++ b/northbound/session/session-impl/src/main/java/org/eclipse/sensinact/northbound/session/impl/SensinactSessionEventListener.java
@@ -18,6 +18,7 @@ import static org.eclipse.sensinact.core.authorization.PermissionLevel.READ;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 
 import org.eclipse.sensinact.core.authorization.Authorizer;
 import org.eclipse.sensinact.core.notification.ClientActionListener;
@@ -29,6 +30,7 @@ import org.eclipse.sensinact.core.notification.ResourceActionNotification;
 import org.eclipse.sensinact.core.notification.ResourceDataNotification;
 import org.eclipse.sensinact.core.notification.ResourceMetaDataNotification;
 import org.eclipse.sensinact.core.notification.ResourceNotification;
+import org.eclipse.sensinact.core.notification.TopicUtils;
 import org.osgi.service.typedevent.TypedEventHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,7 +49,7 @@ public class SensinactSessionEventListener extends AbstractSensinactSessionEvent
 
 
     public SensinactSessionEventListener(String sessionId,
-            String subscriptionId, List<String> topics, Authorizer authorizer,
+            String subscriptionId, List<String> topics, boolean escapeTopics, Authorizer authorizer,
             ClientLifecycleListener lifecycleListener, ClientDataListener dataListener,
             ClientMetadataListener metadataListener, ClientActionListener actionListener) {
         super(sessionId, subscriptionId, topics, authorizer);
@@ -85,7 +87,8 @@ public class SensinactSessionEventListener extends AbstractSensinactSessionEvent
         if(prefixes.isEmpty()) {
             throw new IllegalArgumentException("At least one listener type must be specified");
         }
-        registeredTopics = prefixes.stream().flatMap(p -> topics.stream().map(p::concat)).toList();
+        registeredTopics = prefixes.stream().flatMap(p -> topics.stream().map(p::concat))
+                .map(escapeTopics ? TopicUtils::escapeTopicFilter : Function.identity()).toList();
     }
 
     public List<String> getRegisteredTopics() {

--- a/northbound/session/session-impl/src/test/java/org/eclipse/sensinact/northbound/session/integration/SessionSubscribeTest.java
+++ b/northbound/session/session-impl/src/test/java/org/eclipse/sensinact/northbound/session/integration/SessionSubscribeTest.java
@@ -27,6 +27,7 @@ import java.util.concurrent.TimeUnit;
 import org.eclipse.sensinact.core.command.AbstractTwinCommand;
 import org.eclipse.sensinact.core.command.GatewayThread;
 import org.eclipse.sensinact.core.notification.ResourceDataNotification;
+import org.eclipse.sensinact.core.notification.TopicUtils;
 import org.eclipse.sensinact.core.push.DataUpdate;
 import org.eclipse.sensinact.core.push.dto.GenericDto;
 import org.eclipse.sensinact.core.snapshot.ICriterion;
@@ -49,6 +50,8 @@ import org.eclipse.sensinact.northbound.session.impl.SessionManager;
 import org.eclipse.sensinact.northbound.session.impl.TestUserInfo;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.osgi.test.common.annotation.InjectService;
 import org.osgi.test.common.annotation.Property;
 import org.osgi.test.common.annotation.config.WithConfiguration;
@@ -362,51 +365,96 @@ public class SessionSubscribeTest {
         assertNull(queue.poll(1, TimeUnit.SECONDS));
     }
 
-    @Test
-    void subscribeSpecialCharactersTopic() throws Exception {
+    @ParameterizedTest
+    @CsvSource({"some~provider", "some#other$provider", "πάροχος", "sağlayıcı", "प्रदाता",
+        "المزود", "供應商", "постачальник"})
+    void subscribeSpecialCharactersTopic(String providerName) throws Exception {
 
         SensiNactSession session = sessionManager.getDefaultSession(FRED);
         Random random = new Random();
+        BlockingQueue<ResourceDataNotification> queue = new ArrayBlockingQueue<>(32);
+        String subId = session.addListener(List.of(MODEL + "/" + providerName + "/*"),
+                (t, e) -> queue.offer(e), null, null, null);
+        assertNotNull(subId, "No subscription created for provider " + providerName);
 
-        for (String providerName : List.of("some~provider", "some#other$provider", "πάροχος", "sağlayıcı", "प्रदाता",
-                "المزود", "供應商", "постачальник", "éà@()/:-?øþæ€ł🔟")) {
-            BlockingQueue<ResourceDataNotification> queue = new ArrayBlockingQueue<>(32);
-            String subId = session.addListener(List.of(MODEL + "/" + providerName + "/*"), (t, e) -> queue.offer(e),
-                    null, null, null);
-            assertNotNull(subId, "No subscription created for provider " + providerName);
+        try {
+            // Wait for the listener to be registered in the OSGi service registry
+            // (registration is asynchronous in doAddListener)
+            assertNull(queue.poll(500, TimeUnit.MILLISECONDS),
+                    "Unexpected early notification for provider " + providerName);
 
-            try {
-                // Wait for the listener to be registered in the OSGi service registry
-                // (registration is asynchronous in doAddListener)
-                assertNull(queue.poll(500, TimeUnit.MILLISECONDS),
-                        "Unexpected early notification for provider " + providerName);
+            int newValue = random.nextInt(32000);
+            pushDto(providerName, newValue);
 
-                int newValue = random.nextInt(32000);
-                pushDto(providerName, newValue);
+            ResourceDataNotification notification;
+            do {
+                notification = queue.poll(10, TimeUnit.SECONDS);
+                assertNotNull(notification, "No notification received for provider " + providerName);
+                assertEquals(providerName, notification.provider());
+            } while (!RESOURCE.equals(notification.resource()));
+            assertEquals(SERVICE, notification.service());
+            assertNull(notification.oldValue(), "Got an old value");
+            assertEquals(newValue, notification.newValue());
+        } finally {
+            session.removeListener(subId);
 
-                ResourceDataNotification notification;
-                do {
-                    notification = queue.poll(10, TimeUnit.SECONDS);
-                    assertNotNull(notification, "No notification received for provider " + providerName);
-                    assertEquals(providerName, notification.provider());
-                } while (!RESOURCE.equals(notification.resource()));
-                assertEquals(SERVICE, notification.service());
-                assertNull(notification.oldValue(), "Got an old value");
-                assertEquals(newValue, notification.newValue());
-            } finally {
-                session.removeListener(subId);
-
-                thread.execute(new AbstractTwinCommand<Void>() {
-                    @Override
-                    protected Promise<Void> call(SensinactDigitalTwin twin, PromiseFactory pf) {
-                        SensinactProvider sp = twin.getProvider(providerName);
-                        if (sp != null) {
-                            sp.delete();
-                        }
-                        return pf.resolved(null);
+            thread.execute(new AbstractTwinCommand<Void>() {
+                @Override
+                protected Promise<Void> call(SensinactDigitalTwin twin, PromiseFactory pf) {
+                    SensinactProvider sp = twin.getProvider(providerName);
+                    if (sp != null) {
+                        sp.delete();
                     }
-                }).getValue();
-            }
+                    return pf.resolved(null);
+                }
+            }).getValue();
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource({"some~provider", "some#other$provider", "πάροχος", "sağlayıcı", "प्रदाता",
+        "المزود", "供應商", "постачальник", "éà@()/:-?øþæ€ł🔟"})
+    void subscribeSpecialCharactersPreEscapedTopic(String providerName) throws Exception {
+
+        SensiNactSession session = sessionManager.getDefaultSession(FRED);
+        Random random = new Random();
+        BlockingQueue<ResourceDataNotification> queue = new ArrayBlockingQueue<>(32);
+        String subId = session.addListener(List.of(MODEL + "/" +
+                TopicUtils.escapeTopicPart(providerName, false) + "/*"), false, (t, e) -> queue.offer(e),
+                null, null, null);
+        assertNotNull(subId, "No subscription created for provider " + providerName);
+
+        try {
+            // Wait for the listener to be registered in the OSGi service registry
+            // (registration is asynchronous in doAddListener)
+            assertNull(queue.poll(500, TimeUnit.MILLISECONDS),
+                    "Unexpected early notification for provider " + providerName);
+
+            int newValue = random.nextInt(32000);
+            pushDto(providerName, newValue);
+
+            ResourceDataNotification notification;
+            do {
+                notification = queue.poll(10, TimeUnit.SECONDS);
+                assertNotNull(notification, "No notification received for provider " + providerName);
+                assertEquals(providerName, notification.provider());
+            } while (!RESOURCE.equals(notification.resource()));
+            assertEquals(SERVICE, notification.service());
+            assertNull(notification.oldValue(), "Got an old value");
+            assertEquals(newValue, notification.newValue());
+        } finally {
+            session.removeListener(subId);
+
+            thread.execute(new AbstractTwinCommand<Void>() {
+                @Override
+                protected Promise<Void> call(SensinactDigitalTwin twin, PromiseFactory pf) {
+                    SensinactProvider sp = twin.getProvider(providerName);
+                    if (sp != null) {
+                        sp.delete();
+                    }
+                    return pf.resolved(null);
+                }
+            }).getValue();
         }
     }
 }

--- a/northbound/websocket/src/main/java/org/eclipse/sensinact/northbound/ws/impl/WebSocketEndpoint.java
+++ b/northbound/websocket/src/main/java/org/eclipse/sensinact/northbound/ws/impl/WebSocketEndpoint.java
@@ -18,13 +18,17 @@ import static org.eclipse.sensinact.northbound.query.dto.query.QuerySnapshotDTO.
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.Arrays;
-import java.util.HashSet;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiPredicate;
@@ -41,8 +45,6 @@ import org.eclipse.jetty.websocket.api.annotations.OnWebSocketError;
 import org.eclipse.jetty.websocket.api.annotations.OnWebSocketFrame;
 import org.eclipse.jetty.websocket.api.annotations.OnWebSocketMessage;
 import org.eclipse.jetty.websocket.api.annotations.WebSocket;
-import org.eclipse.sensinact.core.notification.ClientDataListener;
-import org.eclipse.sensinact.core.notification.ClientLifecycleListener;
 import org.eclipse.sensinact.core.notification.LifecycleNotification;
 import org.eclipse.sensinact.core.notification.ResourceDataNotification;
 import org.eclipse.sensinact.core.notification.ResourceNotification;
@@ -121,7 +123,7 @@ public class WebSocketEndpoint {
     /**
      * Active subscriptions
      */
-    private final Set<String> subscriptions = new HashSet<>();
+    private final Set<String> subscriptions = Collections.newSetFromMap(new ConcurrentHashMap<>());
 
     /**
      * Activity check in progress flag
@@ -423,6 +425,7 @@ public class WebSocketEndpoint {
         final SensinactPath path = query.uri;
         CountDownLatch latch = new CountDownLatch(1);
         final AtomicReference<String> listenerId = new AtomicReference<>();
+        final BlockingQueue<Entry<AbstractResultNotificationDTO, String>> queuedNotifications = new LinkedBlockingQueue<>();
 
         final ResultSubscribeDTO result = new ResultSubscribeDTO();
         if(path != null) {
@@ -431,20 +434,19 @@ public class WebSocketEndpoint {
 
         String id = switch(query.subscriptionType == null ? SubscriptionType.EVENTS : query.subscriptionType) {
         case SNAPSHOTS:
-            yield handleSnapshotSubscription(query, path, latch, listenerId);
+            yield handleSnapshotSubscription(query, path, latch, listenerId, queuedNotifications);
         case EVENTS:
         default:
-            yield handleEventSubscription(query, path, latch, listenerId);
+            yield handleEventSubscription(query, path, latch, listenerId, queuedNotifications);
         };
         if(id == null) {
             // The error will already have been sent
             return;
         }
-        listenerId.set(id);
 
         // Store listener details
         subscriptions.add(id);
-        // Send the subscription response to the client
+        // First send the subscription response to the client
         result.statusCode = 200;
         result.subscriptionId = id;
         result.requestId = requestId;
@@ -455,6 +457,12 @@ public class WebSocketEndpoint {
                 userSession.removeListener(id);
             } else {
                 sendResult(ws, result);
+            }
+            // Now tell the listener the id and dequeue any pending work
+            listenerId.set(id);
+            Entry<AbstractResultNotificationDTO, String> toSend;
+            while((toSend = queuedNotifications.poll(5, TimeUnit.MILLISECONDS)) != null) {
+                sendNotification(ws, id, toSend.getKey(), toSend.getValue());
             }
         } catch (Exception e) {
             subscriptions.remove(id);
@@ -469,7 +477,7 @@ public class WebSocketEndpoint {
     }
 
     private String handleSnapshotSubscription(QuerySubscribeDTO query, SensinactPath path, CountDownLatch latch,
-            AtomicReference<String> listenerId) throws StatusException {
+            AtomicReference<String> listenerId, BlockingQueue<Entry<AbstractResultNotificationDTO, String>> pending) throws StatusException {
         if(query.filter == null || query.filter.isBlank()) {
             sendError(wsSession.get(), path, 400, "A filter is required for snapshot subscriptions");
             return null;
@@ -484,30 +492,24 @@ public class WebSocketEndpoint {
                 query.filterLanguage == null ? RESOURCE_SELECTOR_FILTER : query.filterLanguage);
 
         Function<ProviderSnapshot, SnapshotProviderDTO> mapper = ps -> queryHandler.toSnapshotProviderDTO(ps, List.of(FULL), true);
-
-        Consumer<SnapshotUpdate> handler = update -> {
-            try {
-                Session ws = wsSession.get();
-                if (ws == null || !ws.isOpen()) {
-                    logger.warn("Detected closed WebSocket. Stop listening");
-                    userSession.removeListener(listenerId.get());
-                } else if (checkLatch(latch)) {
-                    ResultSnapshotNotificationDTO dto = new ResultSnapshotNotificationDTO();
-                    dto.notification = new SnapshotUpdateNotificationDTO(
-                            update.arriving().entrySet().stream().collect(toMap(Entry::getKey, e -> mapper.apply(e.getValue()))),
-                            update.modified().entrySet().stream().collect(toMap(Entry::getKey, e -> mapper.apply(e.getValue()))),
-                            update.departing());
-                    sendNotification(ws, listenerId.get(), dto, null);
-                }
-            } catch (Throwable e) {
-                logger.warn("Error notifying WebSocket of life cycle update", e);
-            }
+        Function<SnapshotUpdate, ResultSnapshotNotificationDTO> eventFactory = update -> {
+            ResultSnapshotNotificationDTO dto = new ResultSnapshotNotificationDTO();
+            dto.notification = new SnapshotUpdateNotificationDTO(
+                    update.arriving().entrySet().stream().collect(toMap(Entry::getKey, e -> mapper.apply(e.getValue()))),
+                    update.modified().entrySet().stream().collect(toMap(Entry::getKey, e -> mapper.apply(e.getValue()))),
+                    update.departing());
+            return dto;
         };
+
+        Consumer<SnapshotUpdate> handler = handleNotification(null, eventFactory, x -> null, latch,
+                listenerId, pending, "Error notifying WebSocket of snapshot update");
+
         return userSession.subscribe(filter, handler);
     }
 
     private String handleEventSubscription(final QuerySubscribeDTO query, final SensinactPath path,
-            CountDownLatch latch, final AtomicReference<String> listenerId)
+            CountDownLatch latch, final AtomicReference<String> listenerId,
+            BlockingQueue<Entry<AbstractResultNotificationDTO, String>> pending)
             throws StatusException {
         List<String> topics;
         final Predicate<ResourceNotification> eventPredicate;
@@ -533,42 +535,58 @@ public class WebSocketEndpoint {
             p = eventPredicate;
         }
 
-        final ClientDataListener cld = (topic, evt) -> {
+        Function<ResourceNotification, String> pathFactory = evt ->
+            new SensinactPath(evt.provider(), evt.service(), evt.resource()).toUri();
+        Function<ResourceDataNotification, ResultResourceNotificationDTO> dataEventFactory = evt -> {
+            ResultResourceNotificationDTO dto = new ResultResourceNotificationDTO();
+            dto.notification = new ResourceDataNotificationDTO(evt);
+            return dto;
+        };
+        final Consumer<ResourceDataNotification> cld = handleNotification(p, dataEventFactory, pathFactory,
+                latch, listenerId, pending, "Error notifying WebSocket of a data update");
+
+        Function<LifecycleNotification, ResultResourceNotificationDTO> lifecycleEventFactory = evt -> {
+            ResultResourceNotificationDTO dto = new ResultResourceNotificationDTO();
+            dto.notification = new ResourceLifecycleNotificationDTO(evt);
+            return dto;
+        };
+        final Consumer<LifecycleNotification> cll = handleNotification(p, lifecycleEventFactory,
+                pathFactory, latch, listenerId, pending, "Error notifying WebSocket of life cycle update");
+
+        return userSession.addListener(topics, (topic, evt) -> cld.accept(evt), null, (topic, evt) -> cll.accept(evt), null);
+    }
+
+    private <T> Consumer<T> handleNotification(
+            Predicate<? super T> filter, Function<? super T, ? extends AbstractResultNotificationDTO> notificationFactory,
+            Function<? super T, String> pathFactory, CountDownLatch latch, AtomicReference<String> listenerId,
+            BlockingQueue<Entry<AbstractResultNotificationDTO, String>> pending, String failureMessage) {
+        return evt -> {
             try {
                 Session ws = wsSession.get();
                 if (ws == null || !ws.isOpen()) {
                     logger.warn("Detected closed WebSocket. Stop listening");
                     userSession.removeListener(listenerId.get());
-                } else if ((p == null || p.test(evt)) && checkLatch(latch)) {
-                    ResultResourceNotificationDTO dto = new ResultResourceNotificationDTO();
-                    dto.notification = new ResourceDataNotificationDTO(evt);
-                    sendNotification(ws, listenerId.get(), dto,
-                            new SensinactPath(evt.provider(), evt.service(), evt.resource()).toUri());
+                } else if (filter == null || filter.test(evt)) {
+                    AbstractResultNotificationDTO dto = notificationFactory.apply(evt);
+                    String id = listenerId.get();
+                    // No id set until the id notification is sent. If this isn't
+                    // sent yet then don't block
+                    if(id == null) {
+                        pending.offer(new SimpleImmutableEntry<>(dto, pathFactory.apply(evt)));
+                    } else if (checkLatch(latch)) {
+                        Entry<AbstractResultNotificationDTO, String> stillQueued; ;
+                        while((stillQueued = pending.poll()) != null) {
+                            sendNotification(ws, id, stillQueued.getKey(), stillQueued.getValue());
+                        }
+                        sendNotification(ws, id, dto, pathFactory.apply(evt));
+                    } else {
+                        logger.warn("Ignoring message due to long wait. {}", failureMessage);
+                    }
                 }
             } catch (Throwable e) {
-                logger.warn("Error notifying WebSocket of life cycle update", e);
+                logger.warn(failureMessage, e);
             }
         };
-
-        final ClientLifecycleListener cll = (topic, evt) -> {
-            try {
-                Session ws = wsSession.get();
-                if (ws == null || !ws.isOpen()) {
-                    logger.warn("Detected closed WebSocket. Stop listening");
-                    userSession.removeListener(listenerId.get());
-                } else if ((p == null || p.test(evt)) && checkLatch(latch)) {
-                    ResultResourceNotificationDTO dto = new ResultResourceNotificationDTO();
-                    dto.notification = new ResourceLifecycleNotificationDTO(evt);
-                    sendNotification(ws, listenerId.get(), dto,
-                            new SensinactPath(evt.provider(), evt.service(), evt.resource()).toUri());
-                }
-            } catch (Throwable e) {
-                logger.error("Error notifying WebSocket of a data update", e);
-            }
-        };
-
-        String id = userSession.addListener(topics, cld, null, cll, null);
-        return id;
     }
 
     private boolean checkLatch(CountDownLatch latch) {

--- a/southbound/history/timescale-provider/src/main/java/org/eclipse/sensinact/gateway/southbound/history/timescale/TimescaleHistoricalStore.java
+++ b/southbound/history/timescale-provider/src/main/java/org/eclipse/sensinact/gateway/southbound/history/timescale/TimescaleHistoricalStore.java
@@ -28,7 +28,6 @@ import org.eclipse.sensinact.core.command.AbstractSensinactCommand;
 import org.eclipse.sensinact.core.command.AbstractTwinCommand;
 import org.eclipse.sensinact.core.command.GatewayThread;
 import org.eclipse.sensinact.core.model.SensinactModelManager;
-import org.eclipse.sensinact.core.notification.TopicUtils;
 import org.eclipse.sensinact.core.snapshot.ICriterion;
 import org.eclipse.sensinact.core.twin.SensinactDigitalTwin;
 import org.eclipse.sensinact.core.twin.SensinactProvider;
@@ -325,7 +324,7 @@ public class TimescaleHistoricalStore {
             }
 
             List<String> dataTopics = Optional.ofNullable(include.dataTopics())
-                    .map(l -> l.stream().filter(Objects::nonNull).map(TopicUtils::escapeTopicFilter).toList())
+                    .map(l -> l.stream().filter(Objects::nonNull).toList())
                     .orElse(null);
 
             reg = ctx.registerService(TypedEventHandler.class,

--- a/southbound/rules/rules.impl/src/main/java/org/eclipse/sensinact/southbound/rules/impl/RuleProcessor.java
+++ b/southbound/rules/rules.impl/src/main/java/org/eclipse/sensinact/southbound/rules/impl/RuleProcessor.java
@@ -36,7 +36,6 @@ import org.eclipse.sensinact.core.metrics.IMetricTimer;
 import org.eclipse.sensinact.core.metrics.IMetricsManager;
 import org.eclipse.sensinact.core.model.SensinactModelManager;
 import org.eclipse.sensinact.core.notification.ResourceDataNotification;
-import org.eclipse.sensinact.core.notification.TopicUtils;
 import org.eclipse.sensinact.core.snapshot.ICriterion;
 import org.eclipse.sensinact.core.snapshot.ProviderSnapshot;
 import org.eclipse.sensinact.core.snapshot.ResourceSnapshot;
@@ -101,7 +100,7 @@ public class RuleProcessor implements TypedEventHandler<ResourceDataNotification
         this.timerName = sanitizedMetricPrefix + ".execution";
 
         List<String> dataTopics = Optional.ofNullable(criterion.dataTopics())
-                .map(l -> l.stream().filter(Objects::nonNull).map(TopicUtils::escapeTopicFilter).toList())
+                .map(l -> l.stream().filter(Objects::nonNull).toList())
                 .orElse(null);
 
         reg = context.registerService(TypedEventHandler.class, this,


### PR DESCRIPTION
This commit tidies up the topic escaping process so that we are more resilient to the / character in topic segments. It also improves the topic escaping to be faster, using loops and switches rather than regex. The result is that users no longer need to worry about escaping their topic segments.