### PR TITLE
Filtering fixes for snapshots

### DIFF
--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -8,9 +8,9 @@ maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.18.1, Apache-2.0 AN
 maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.21.2, Apache-2.0 AND MIT, approved, #25590
 maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.8.8, Apache-2.0, approved, CQ13170
 maven/mavencentral/com.fasterxml.jackson.core/jackson-core/2.9.6, Apache-2.0, approved, CQ13983
+maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.14.1, Apache-2.0, approved, #15232
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.18.1, Apache-2.0, approved, #16372
 maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.21.2, Apache-2.0, approved, #25591
-maven/mavencentral/com.fasterxml.jackson.core/jackson-databind/2.8.8, Apache-2.0, approved, CQ13503
 maven/mavencentral/com.github.docker-java/docker-java-api/3.7.0, Apache-2.0, approved, #26612
 maven/mavencentral/com.github.docker-java/docker-java-transport-zerodep/3.7.0, Apache-2.0 AND MPL-2.0, approved, #25269
 maven/mavencentral/com.github.docker-java/docker-java-transport/3.7.0, Apache-2.0, approved, #26615

--- a/core/impl/src/main/java/org/eclipse/sensinact/core/twin/impl/SensinactDigitalTwinImpl.java
+++ b/core/impl/src/main/java/org/eclipse/sensinact/core/twin/impl/SensinactDigitalTwinImpl.java
@@ -358,7 +358,7 @@ public class SensinactDigitalTwinImpl extends CommandScopedImpl implements Sensi
         providersStream = providersStream.map(p -> {
             snapshotServicesAndResources(svcFilter, rcFilter, snapshotTime, p, false);
             return p;
-        }).filter(p -> !p.getServices().isEmpty());
+        });
 
         return providersStream.collect(Collectors.toList());
     }

--- a/core/impl/src/test/java/org/eclipse/sensinact/core/twin/impl/SensinactTwinTest.java
+++ b/core/impl/src/test/java/org/eclipse/sensinact/core/twin/impl/SensinactTwinTest.java
@@ -538,7 +538,8 @@ public class SensinactTwinTest {
             Predicate<ResourceSnapshot> p = r -> "foo".equals(r.getName());
 
             List<ProviderSnapshot> list = twinImpl.filteredSnapshot(null, null, null, p);
-            assertEquals(1, list.size());
+            assertEquals(2, list.size());
+            ProviderSnapshot ps = list.stream().filter(s -> s.getName().equals("sensor")).findFirst().get();
             assertEquals(2, list.get(0).getServices().size());
             ServiceSnapshot serviceSnapshot = list.get(0).getService(TEST_SERVICE);
             assertNotNull(serviceSnapshot);

--- a/filters/resource.selector.impl/src/main/java/org/eclipse/sensinact/filters/resource/selector/impl/ProviderSelectionCriterion.java
+++ b/filters/resource.selector.impl/src/main/java/org/eclipse/sensinact/filters/resource/selector/impl/ProviderSelectionCriterion.java
@@ -55,7 +55,8 @@ public class ProviderSelectionCriterion {
         if(resources.isEmpty()) {
             this.serviceFilter = never();
             this.resourceFilter = never();
-            this.valueFilter = (x,y) -> Boolean.TRUE;
+            // It must target the correct provider, even though there are no values to check
+            this.valueFilter = (x,y) -> providerFilter.test(x);
         } else {
             this.serviceFilter = combineServiceCheck(providerFilter, resources.stream()
                             .map(ResourceSelectionCriterion::serviceFilter)

--- a/filters/resource.selector.impl/src/test/java/org/eclipse/sensinact/filters/resource/selector/impl/ResourceSelectorTest.java
+++ b/filters/resource.selector.impl/src/test/java/org/eclipse/sensinact/filters/resource/selector/impl/ResourceSelectorTest.java
@@ -275,6 +275,36 @@ public class ResourceSelectorTest {
                 List.of(rcDoesNotMatch)));
     }
 
+    @Test
+    void withoutValueAllResources() {
+        ResourceSelector rs = makeBasicResourceSelector("foo", null, null, null);
+        ResourceSnapshot rc = makeResource("test", "hello", "foo");
+
+        ICriterion filter = new ResourceSelectorCriterion(rs, false);
+        assertFalse(filter.getProviderFilter().test(rc.getService().getProvider()));
+        assertFalse(filter.getServiceFilter().test(rc.getService()));
+        assertFalse(filter.getResourceFilter().test(rc));
+        // Does not match as the provider is wrong
+        assertFalse(filter.getResourceValueFilter().test(rc.getService().getProvider(),
+                List.of(rc)));
+    }
+
+    @Test
+    void withoutValueOrResourceSelection() {
+        ResourceSelector rs = new ResourceSelector(List.of(
+                new ProviderSelection(null, new Selection("foo"), null, null, null)),
+                List.of());
+        ResourceSnapshot rc = makeResource("test", "hello", "foo");
+
+        ICriterion filter = new ResourceSelectorCriterion(rs, false);
+        assertFalse(filter.getProviderFilter().test(rc.getService().getProvider()));
+        assertFalse(filter.getServiceFilter().test(rc.getService()));
+        assertFalse(filter.getResourceFilter().test(rc));
+        // Does not match as the provider is wrong
+        assertFalse(filter.getResourceValueFilter().test(rc.getService().getProvider(),
+                List.of(rc)));
+    }
+
     static Stream<Object> testValues() {
         return Stream.of("test", 42, 51L, 43.5);
     }

--- a/filters/resource.selector.impl/src/test/java/org/eclipse/sensinact/filters/resource/selector/impl/ResourceSelectorTest.java
+++ b/filters/resource.selector.impl/src/test/java/org/eclipse/sensinact/filters/resource/selector/impl/ResourceSelectorTest.java
@@ -15,6 +15,7 @@ package org.eclipse.sensinact.filters.resource.selector.impl;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Instant;
@@ -39,7 +40,6 @@ import org.eclipse.sensinact.filters.resource.selector.api.ResourceSelector;
 import org.eclipse.sensinact.filters.resource.selector.api.ResourceSelector.ProviderSelection;
 import org.eclipse.sensinact.filters.resource.selector.api.ResourceSelector.ResourceSelection;
 import org.eclipse.sensinact.filters.resource.selector.api.Selection;
-import org.eclipse.sensinact.filters.resource.selector.api.Selection.MatchType;
 import org.eclipse.sensinact.filters.resource.selector.api.ValueSelection;
 import org.eclipse.sensinact.filters.resource.selector.api.ValueSelection.CheckType;
 import org.eclipse.sensinact.filters.resource.selector.api.ValueSelection.OperationType;
@@ -222,17 +222,13 @@ public class ResourceSelectorTest {
     }
 
     private ResourceSelector makeBasicResourceSelector(String model, String provider, String service, String resource) {
-        List<ResourceSelection> resources = List.of(new ResourceSelection(service == null ? null : makeExactSelection(service),
-                resource == null ? null : makeExactSelection(resource), List.of()));
+        List<ResourceSelection> resources = List.of(new ResourceSelection(service == null ? null : new Selection(service),
+                resource == null ? null : new Selection(resource), List.of()));
         ProviderSelection ps = new ProviderSelection(null,
-                model == null ? null : makeExactSelection(model),
-                provider == null ? null : makeExactSelection(provider),
+                model == null ? null : new Selection(model),
+                provider == null ? null : new Selection(provider),
                 resources, List.of());
         return new ResourceSelector(List.of(ps), List.of());
-    }
-
-    private Selection makeExactSelection(String name) {
-        return new Selection(name, MatchType.EXACT, false);
     }
 
     private ValueSelection makeValueSelection(String value, CheckType check, OperationType operation) {
@@ -253,6 +249,30 @@ public class ResourceSelectorTest {
         ProviderSelection newer = new ProviderSelection(existingP.modelUri(), existingP.model(), existingP.provider(),
                 List.of(new ResourceSelection(exisitingR.service(), exisitingR.resource(), List.of(vs))), existingP.location());
         return new ResourceSelector(List.of(newer), rs.resources());
+    }
+
+    @Test
+    void withoutValueSelection() {
+        ResourceSelector rs = makeBasicResourceSelector(null, null, "test", "hello");
+        ResourceSnapshot rcMatches = makeResource("test", "hello", "foo");
+        ResourceSnapshot rcDoesNotMatch = makeResource("test", "bye", "bar");
+
+        ICriterion filter = new ResourceSelectorCriterion(rs, false);
+        assertNull(filter.getProviderFilter());
+        assertTrue(filter.getServiceFilter().test(rcMatches.getService()));
+        assertTrue(filter.getResourceFilter().test(rcMatches));
+        assertTrue(filter.getResourceValueFilter().test(rcMatches.getService().getProvider(),
+                List.of(rcMatches)));
+        // Does not match if the resource is missing
+        assertFalse(filter.getResourceValueFilter().test(rcMatches.getService().getProvider(),
+                List.of()));
+
+        assertNull(filter.getProviderFilter());
+        assertTrue(filter.getServiceFilter().test(rcDoesNotMatch.getService()));
+        assertFalse(filter.getResourceFilter().test(rcDoesNotMatch));
+        // Does not match if the resource is different
+        assertFalse(filter.getResourceValueFilter().test(rcDoesNotMatch.getService().getProvider(),
+                List.of(rcDoesNotMatch)));
     }
 
     static Stream<Object> testValues() {

--- a/filters/resource.selector/src/main/java/org/eclipse/sensinact/filters/resource/selector/api/CompactResourceSelector.java
+++ b/filters/resource.selector/src/main/java/org/eclipse/sensinact/filters/resource/selector/api/CompactResourceSelector.java
@@ -63,7 +63,7 @@ public record CompactResourceSelector(Selection modelUri, Selection model, Selec
 
     public ResourceSelector toResourceSelector() {
         ResourceSelection rs = new ResourceSelection(service, resource, value);
-        ProviderSelection ps = new ProviderSelection(modelUri, model, provider, value.isEmpty() ? List.of() : List.of(rs), location);
-        return new ResourceSelector(List.of(ps), value().isEmpty() ? List.of(rs) : List.of());
+        ProviderSelection ps = new ProviderSelection(modelUri, model, provider, List.of(rs), location);
+        return new ResourceSelector(List.of(ps), List.of());
     }
 }

--- a/filters/resource.selector/src/test/java/org/eclipse/sensinact/gateway/filters/resource/selector/api/JsonSerializationTests.java
+++ b/filters/resource.selector/src/test/java/org/eclipse/sensinact/gateway/filters/resource/selector/api/JsonSerializationTests.java
@@ -16,6 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -96,7 +97,7 @@ class JsonSerializationTests {
                     ResourceSelector.class);
 
             assertEquals(1, selector.providers().size());
-            assertEquals(1, selector.resources().size());
+            assertEquals(List.of(), selector.resources());
 
             ProviderSelection ps = selector.providers().get(0);
             assertNotNull(ps);
@@ -106,9 +107,9 @@ class JsonSerializationTests {
             assertNull(ps.provider());
 
             assertEquals(List.of(), ps.location());
-            assertEquals(List.of(), ps.resources());
+            assertEquals(1, ps.resources().size());
 
-            ResourceSelection rs = selector.resources().get(0);
+            ResourceSelection rs = ps.resources().get(0);
             assertNotNull(rs);
 
             assertNull(rs.service());
@@ -162,14 +163,15 @@ class JsonSerializationTests {
             assertNull(ps.model());
             assertNull(ps.provider());
             assertEquals(List.of(), ps.location());
-            assertEquals(List.of(), ps.resources());
 
             // Should select all resources
-            assertEquals(1, empty.resources().size());
-            assertNotNull(empty.resources().get(0));
-            assertNull(empty.resources().get(0).service());
-            assertNull(empty.resources().get(0).resource());
-            assertEquals(List.of(), empty.resources().get(0).value());
+            assertEquals(1, ps.resources().size());
+            assertNotNull(ps.resources().get(0));
+            assertNull(ps.resources().get(0).service());
+            assertNull(ps.resources().get(0).resource());
+            assertEquals(List.of(), ps.resources().get(0).value());
+
+            assertTrue(empty.resources().isEmpty());
         }
     }
 

--- a/northbound/rest/src/test/java/org/eclipse/sensinact/northbound/rest/integration/ResourceSnapshotTest.java
+++ b/northbound/rest/src/test/java/org/eclipse/sensinact/northbound/rest/integration/ResourceSnapshotTest.java
@@ -229,4 +229,47 @@ public class ResourceSnapshotTest {
         assertEquals("java.lang.Integer", response.type);
     }
 
+    /**
+     * Get the resource value
+     */
+    @Test
+    void testValueSelections() throws Exception {
+        // Register the resource
+        GenericDto dto = utils.makeDto("M1", "P1", "S1", "R1", "V1", String.class);
+        push.pushUpdate(dto).getValue();
+        dto = utils.makeDto("M1", "P2", "S1", "R1", "V2", String.class);
+        push.pushUpdate(dto).getValue();
+        dto = utils.makeDto("M2", "P3", "S1", "R1", "V1", String.class);
+        push.pushUpdate(dto).getValue();
+
+        ResourceSelection service1Resource1WithValueV1 = new ResourceSelection(new Selection("S1"), new Selection("R1"), List.of(new ValueSelection("V1")));
+        List<ResourceSelector> request = new ArrayList<>();
+        ResourceSelector rs = new ResourceSelector(List.of(new ProviderSelection(
+                null, new Selection("M1"), null, List.of(service1Resource1WithValueV1), null)),
+                List.of());
+        request.add(rs);
+        rs = new ResourceSelector(List.of(
+                new ProviderSelection(null, new Selection("M2"), null, null, null)),
+                List.of());
+        request.add(rs);
+        ResponseSnapshotDTO response = utils.queryJson("snapshot", request, ResponseSnapshotDTO.class);
+
+        assertEquals(2, response.providers.size());
+        SnapshotProviderDTO providerDTO = response.providers.get("P1");
+        assertEquals("P1", providerDTO.name);
+        assertEquals("M1", providerDTO.modelName);
+        assertEquals(1, providerDTO.services.size());
+        SnapshotServiceDTO serviceDTO = providerDTO.services.get("S1");
+        assertEquals("S1", serviceDTO.name);
+        assertEquals(1, serviceDTO.resources.size());
+        SnapshotResourceDTO resourceDTO = serviceDTO.resources.get("R1");
+        assertEquals("R1", resourceDTO.name);
+        assertEquals("java.lang.String", resourceDTO.type);
+        assertEquals("V1", resourceDTO.value);
+
+        providerDTO = response.providers.get("P3");
+        assertEquals("P3", providerDTO.name);
+        assertEquals("M2", providerDTO.modelName);
+        assertEquals(Map.of(), providerDTO.services);
+    }
 }

--- a/northbound/rest/src/test/java/org/eclipse/sensinact/northbound/rest/integration/ResourceSnapshotTest.java
+++ b/northbound/rest/src/test/java/org/eclipse/sensinact/northbound/rest/integration/ResourceSnapshotTest.java
@@ -19,12 +19,20 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 
+import org.eclipse.sensinact.core.command.AbstractSensinactCommand;
+import org.eclipse.sensinact.core.command.GatewayThread;
+import org.eclipse.sensinact.core.model.SensinactModelManager;
 import org.eclipse.sensinact.core.notification.ResourceDataNotification;
 import org.eclipse.sensinact.core.push.DataUpdate;
 import org.eclipse.sensinact.core.push.dto.GenericDto;
+import org.eclipse.sensinact.core.twin.SensinactDigitalTwin;
+import org.eclipse.sensinact.core.twin.SensinactProvider;
 import org.eclipse.sensinact.filters.resource.selector.api.CompactResourceSelector;
 import org.eclipse.sensinact.filters.resource.selector.api.ResourceSelector;
+import org.eclipse.sensinact.filters.resource.selector.api.ResourceSelector.ProviderSelection;
+import org.eclipse.sensinact.filters.resource.selector.api.ResourceSelector.ResourceSelection;
 import org.eclipse.sensinact.filters.resource.selector.api.Selection;
+import org.eclipse.sensinact.filters.resource.selector.api.ValueSelection;
 import org.eclipse.sensinact.northbound.query.api.AbstractResultDTO;
 import org.eclipse.sensinact.northbound.query.api.EResultType;
 import org.eclipse.sensinact.northbound.query.dto.result.ResponseGetDTO;
@@ -46,6 +54,8 @@ import org.osgi.test.common.annotation.Property;
 import org.osgi.test.common.annotation.config.InjectConfiguration;
 import org.osgi.test.common.annotation.config.WithConfiguration;
 import org.osgi.test.common.service.ServiceAware;
+import org.osgi.util.promise.Promise;
+import org.osgi.util.promise.PromiseFactory;
 
 import jakarta.ws.rs.core.Application;
 
@@ -85,12 +95,22 @@ public class ResourceSnapshotTest {
     final TestUtils utils = new TestUtils();
 
     @AfterEach
-    void stop() {
+    void stop(@InjectService GatewayThread gt) {
         if (queue != null) {
             SensiNactSession session = sessionManager.getDefaultSession(USER);
             session.activeListeners().keySet().forEach(session::removeListener);
             queue = null;
         }
+        gt.execute(new AbstractSensinactCommand<Void>() {
+
+            @Override
+            protected Promise<Void> call(SensinactDigitalTwin twin, SensinactModelManager modelMgr,
+                    PromiseFactory promiseFactory) {
+                twin.getProviders().stream().filter(p -> p.getModelName().matches("M\\d"))
+                    .forEach(SensinactProvider::delete);
+                return null;
+            }
+        });
     }
 
     /**
@@ -120,6 +140,28 @@ public class ResourceSnapshotTest {
         assertEquals("R1", resourceDTO.name);
         assertEquals("java.lang.String", resourceDTO.type);
         assertEquals("V1", resourceDTO.value);
+    }
+
+    /**
+     * Get an empty provider value
+     */
+    @Test
+    void getEmptyProviderSnapshot() throws Exception {
+        // Register the resource
+        GenericDto dto = utils.makeDto("M1", "P1", "S1", "R1", "V1", String.class);
+        push.pushUpdate(dto).getValue();
+
+        List<ResourceSelector> request = new ArrayList<>();
+        ResourceSelector rs = new ResourceSelector(List.of(
+                new ProviderSelection(null, new Selection("M1"), null, null, null)), List.of());
+        request.add(rs);
+        ResponseSnapshotDTO response = utils.queryJson("snapshot", request, ResponseSnapshotDTO.class);
+
+        assertEquals(1, response.providers.size());
+        SnapshotProviderDTO providerDTO = response.providers.get("P1");
+        assertEquals("P1", providerDTO.name);
+        assertEquals("M1", providerDTO.modelName);
+        assertEquals(Map.of(), providerDTO.services);
     }
 
     /**
@@ -186,4 +228,5 @@ public class ResourceSnapshotTest {
         assertEquals(42, response.value);
         assertEquals("java.lang.Integer", response.type);
     }
+
 }


### PR DESCRIPTION
This PR fixes two bugs in snapshot filtering:

1. A provider snapshot with no services (or services with no resources) should still be returned if it is a suitable match for the filter. This ensures (for example) that someone can easily find all of the providers that have a given model without having to add an unnecessary resource.
2. A resource selector with multiple provider selections, one of which has no resource selections, can result in non-matching results being returned. This can be easily fixed by requiring the provider snapshot to match, even when there are no resources to match.

Note that there is one change in behaviour from this PR. The `SensiNactDigitalTwin` will now return provider snapshots with no services, even if services are required. These must be filtered out by the caller, typically by using the `ResourceValueFilter` from their `ICriterion`. This was already the case in all parts of the codebase, so it is unlikely to be a problem.