### PR TITLE
Avoid leaking mutable collections from the twin

### DIFF
--- a/core/impl/src/main/java/org/eclipse/sensinact/core/model/nexus/ModelNexus.java
+++ b/core/impl/src/main/java/org/eclipse/sensinact/core/model/nexus/ModelNexus.java
@@ -441,10 +441,16 @@ public class ModelNexus {
 
         Map<String, Object> oldMetaData = null;
         Object oldValue = service.eGet(resourceFeature);
-        if (metadata != null) {
-            oldMetaData = EMFCompareUtil.extractMetadataMap(oldValue, metadata, resourceFeature);
+        // Holds an immutable snapshot of the value if it is a {@link Collection}
+        // to prevent race conditions when the underlying EMF list is later modified.
+        if(oldValue instanceof Collection<?> c) {
+            oldValue = List.copyOf(c);
         }
-        if (oldValue == null) {
+        if (metadata != null) {
+            oldMetaData = EMFUtil.toMetadataAttributesToMap(metadata, resourceFeature);
+        }
+        if(metadata == null || metadata.getTimestamp() == null) {
+            // New resource addition
             accumulator.addResource(packageUri, modelName, providerName, serviceName, resourceFeature.getName());
         }
 
@@ -460,6 +466,8 @@ public class ModelNexus {
             }
             metadata.setTimestamp(metaTimestamp);
 
+            // Holds an immutable snapshot of the value if it is a {@link Collection}
+            // to prevent race conditions when the underlying EMF list is later modified.
             final Object storedData;
 
             // Handle multi-valued features (collections)
@@ -475,12 +483,12 @@ public class ModelNexus {
                             list.add(EMFUtil.convertToTargetType(resourceType, item));
                         }
                     }
-                    storedData = list;
+                    storedData = List.copyOf(list);
                 } else if (data == null) {
                     @SuppressWarnings("unchecked")
                     EList<Object> list = (EList<Object>) service.eGet(resourceFeature);
                     list.clear();
-                    storedData = list;
+                    storedData = List.of();
                 } else {
                     // Single value for a multi-valued feature - add it to the list
                     @SuppressWarnings("unchecked")
@@ -491,7 +499,7 @@ public class ModelNexus {
                     } else {
                         list.add(EMFUtil.convertToTargetType(resourceType, data));
                     }
-                    storedData = list;
+                    storedData = List.copyOf(list);
                 }
             } else {
                 // Handle single-valued features
@@ -503,7 +511,7 @@ public class ModelNexus {
                 service.eSet(resourceFeature, storedData);
             }
 
-            Map<String, Object> newMetaData = EMFCompareUtil.extractMetadataMap(storedData, metadata, resourceFeature);
+            Map<String, Object> newMetaData = EMFUtil.toMetadataAttributesToMap(metadata, resourceFeature);
 
             accumulator.resourceValueUpdate(packageUri, modelName, providerName, serviceName, resourceFeature.getName(),
                     resourceType.getInstanceClass(), oldValue, storedData, newMetaData, metaTimestamp);

--- a/core/impl/src/main/java/org/eclipse/sensinact/core/model/nexus/emf/compare/EMFCompareUtil.java
+++ b/core/impl/src/main/java/org/eclipse/sensinact/core/model/nexus/emf/compare/EMFCompareUtil.java
@@ -14,6 +14,7 @@ package org.eclipse.sensinact.core.model.nexus.emf.compare;
 
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -28,7 +29,6 @@ import org.eclipse.emf.ecore.EClass;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EReference;
 import org.eclipse.emf.ecore.EStructuralFeature;
-import org.eclipse.emf.ecore.ETypedElement;
 import org.eclipse.emf.ecore.EcorePackage;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.sensinact.core.model.nexus.emf.EMFUtil;
@@ -256,10 +256,10 @@ public class EMFCompareUtil {
             if (resource instanceof EReference) {
                 if (resource.isMany()) {
                     isEqual = EcoreUtil.equals((List<EObject>) oldValue, (List<EObject>) newValue);
-                    if (!isEqual) {
-                        oldValue = EcoreUtil.copyAll((List<EObject>) oldValue);
-                        newValue = EcoreUtil.copyAll((List<EObject>) newValue);
-                    }
+                    // Holds an immutable snapshot of the value if it is a {@link Collection}
+                    // to prevent race conditions when the underlying EMF list is later modified.
+                    oldValue = EcoreUtil.copyAll((List<EObject>) oldValue);
+                    newValue = EcoreUtil.copyAll((List<EObject>) newValue);
                 } else {
                     isEqual = EcoreUtil.equals((EObject) oldValue, (EObject) newValue);
                     if (!isEqual) {
@@ -311,14 +311,14 @@ public class EMFCompareUtil {
             Map<String, Object> oldMetaData = null;
 
             if (previousTimestamp != null && !previousTimestamp.equals(Instant.EPOCH)) {
-                oldMetaData = extractMetadataMap(oldValue, originalMetadata, resource);
+                oldMetaData = EMFUtil.toMetadataAttributesToMap(originalMetadata, resource);
             }
 
             Metadata updatedMetadata = updateMetadata(resource, newService, originalService, newTimestamp);
 
             originalService.eSet(resource, newValue);
 
-            Map<String, Object> newMetaData = extractMetadataMap(newValue, updatedMetadata, resource);
+            Map<String, Object> newMetaData = EMFUtil.toMetadataAttributesToMap(updatedMetadata, resource);
 
             accumulator.resourceValueUpdate(packageUri, modelName, providerName, serviceName, resource.getName(),
                     resource.getEType().getInstanceClass(), oldValue, newValue, newMetaData, newTimestamp);
@@ -331,13 +331,6 @@ public class EMFCompareUtil {
             }
         }
 
-    }
-
-    public static Map<String, Object> extractMetadataMap(Object value, Metadata updatedMetadata,
-            ETypedElement feature) {
-        Map<String, Object> newMetaData = EMFUtil.toMetadataAttributesToMap(updatedMetadata, feature);
-        newMetaData.put("value", value);
-        return newMetaData;
     }
 
     private static ResourceValueMetadata updateMetadata(EStructuralFeature resource, Service newService,
@@ -395,9 +388,14 @@ public class EMFCompareUtil {
             Metadata metadata = service.getMetadata().get(ea);
             accumulator.addResource(packageUri, model, providerName, serviceName, ea.getName());
             Map<String, Object> newMetaData = EMFUtil.toEObjectAttributesToMap(metadata, true, List.of(), null, null);
-            newMetaData.put("value", service.eGet(ea));
+            Object resourceValue = service.eGet(ea);
+            // Holds an immutable snapshot of the value if it is a {@link Collection}
+            // to prevent race conditions when the underlying EMF list is later modified.
+            if(resourceValue instanceof Collection<?> c) {
+                resourceValue = List.copyOf(c);
+            }
             accumulator.resourceValueUpdate(packageUri, model, providerName, serviceName, ea.getName(),
-                    ea.getEAttributeType().getInstanceClass(), null, service.eGet(ea), newMetaData,
+                    ea.getEAttributeType().getInstanceClass(), null, resourceValue, newMetaData,
                     metadata.getTimestamp());
             accumulator.metadataValueUpdate(packageUri, model, providerName, serviceName, ea.getName(), null,
                     newMetaData, metadata.getTimestamp());

--- a/core/impl/src/main/java/org/eclipse/sensinact/core/notification/impl/AbstractNotificationAccumulatorImpl.java
+++ b/core/impl/src/main/java/org/eclipse/sensinact/core/notification/impl/AbstractNotificationAccumulatorImpl.java
@@ -59,18 +59,7 @@ public abstract class AbstractNotificationAccumulatorImpl implements Notificatio
     protected ResourceDataNotification createResourceDataNotification(String modelPackageUri, String model, String provider, String service,
             String resource, Class<?> type, Object oldValue, Object newValue, Map<String, Object> metadata, Instant timestamp) {
         return new ResourceDataNotification(modelPackageUri, model, provider, service,
-                resource, snapshotValue(oldValue), snapshotValue(newValue), timestamp, type, metadata);
-    }
-
-    /**
-     * Returns an immutable snapshot of the value if it is a {@link Collection},
-     * to prevent race conditions when the underlying EMF list is later modified.
-     */
-    private static Object snapshotValue(Object value) {
-        if (value instanceof Collection<?> col) {
-            return List.copyOf(col);
-        }
-        return value;
+                resource, oldValue, newValue, timestamp, type, metadata);
     }
 
     protected ResourceActionNotification createResourceActionNotification(String modelPackageUri, String model, String provider, String service,

--- a/core/impl/src/main/java/org/eclipse/sensinact/core/twin/impl/SensinactResourceImpl.java
+++ b/core/impl/src/main/java/org/eclipse/sensinact/core/twin/impl/SensinactResourceImpl.java
@@ -341,9 +341,8 @@ public class SensinactResourceImpl extends CommandScopedImpl implements Sensinac
             return (TimedValue<List<T>>) tv;
         }
         Object value = tv.getValue();
-        if(value instanceof List) {
-            return (TimedValue<List<T>>) tv;
-        } else if(value instanceof Collection<?> c) {
+        // We always copy the list to prevent leaking the internals
+        if(value instanceof Collection<?> c) {
             List<T> list = (List<T>) List.copyOf(c);
             return new DefaultTimedValue<>(list, tv.getTimestamp());
         } else {

--- a/core/impl/src/test/java/org/eclipse/sensinact/core/model/nexus/NexusTest.java
+++ b/core/impl/src/test/java/org/eclipse/sensinact/core/model/nexus/NexusTest.java
@@ -18,10 +18,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -36,6 +39,7 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -71,6 +75,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -1304,6 +1309,54 @@ public class NexusTest {
             assertEquals(2, updatedList.size());
             assertTrue(updatedList.contains("x"));
             assertTrue(updatedList.contains("y"));
+        }
+
+
+        @Test
+        void testResourceValueIsSnapshotted() {
+            ModelNexus nexus = new ModelNexus(resourceSet, ProviderPackage.eINSTANCE, () -> accumulator);
+            Instant now = Instant.now();
+
+            EClass model = nexus.createModel(TEST_PKG, TEST_MODEL, now);
+            EReference service = nexus.createService(model, "testservice", "testservice", now);
+
+            // Create a collection resource
+            EAttribute resource = nexus.createResource(service.getEReferenceType(), "testList", String.class, now,
+                    null, Map.of(), false, 0, false, 0, -1);
+
+            Provider p = nexus.createProviderInstance(TEST_PKG, TEST_MODEL, TESTPROVIDER, now);
+
+            // Initial update with a list
+            List<String> initialData = List.of("a", "b", "c");
+            nexus.handleDataUpdate(p, service.getName(), service, service.getEReferenceType(), resource, initialData, now);
+
+            ArgumentCaptor<List<String>> oldCaptor = ArgumentCaptor.captor();
+            ArgumentCaptor<List<String>> newCaptor = ArgumentCaptor.captor();
+            ArgumentCaptor<Map<String, Object>> newMetadataCaptor = ArgumentCaptor.captor();
+
+            Mockito.verify(accumulator).resourceValueUpdate(eq(TEST_PKG), eq(TEST_MODEL), eq(TESTPROVIDER),
+                    eq("testservice"), eq("testList"), any(), oldCaptor.capture(), newCaptor.capture(),
+                    newMetadataCaptor.capture(), eq(now));
+
+            assertEquals(List.of(), oldCaptor.getValue());
+            assertEquals(initialData, newCaptor.getValue());
+            assertNotSame(initialData, newCaptor.getValue());
+
+            assertEquals(Map.of("timestamp", now), newMetadataCaptor.getValue());
+
+            List<String> updatedValue = List.of("a", "b", "c");
+            nexus.handleDataUpdate(p, service.getName(), service, service.getEReferenceType(), resource, updatedValue, now.plusMillis(10));
+
+            Mockito.verify(accumulator).resourceValueUpdate(eq(TEST_PKG), eq(TEST_MODEL), eq(TESTPROVIDER),
+                    eq("testservice"), eq("testList"), any(), oldCaptor.capture(), newCaptor.capture(),
+                    newMetadataCaptor.capture(), eq(now.plusMillis(10)));
+
+            assertEquals(initialData, oldCaptor.getValue());
+            assertNotSame(initialData, oldCaptor.getValue());
+            assertEquals(updatedValue, newCaptor.getValue());
+            assertNotSame(updatedValue, newCaptor.getValue());
+
+            assertEquals(Map.of("timestamp", now.plusMillis(10)), newMetadataCaptor.getValue());
         }
     }
 }

--- a/core/impl/src/test/java/org/eclipse/sensinact/core/model/nexus/SubscriptionTest.java
+++ b/core/impl/src/test/java/org/eclipse/sensinact/core/model/nexus/SubscriptionTest.java
@@ -168,13 +168,12 @@ public class SubscriptionTest {
             Mockito.verify(accumulator).resourceValueUpdate(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER,
                     ProviderPackage.Literals.PROVIDER__ADMIN.getName(),
                     ProviderPackage.Literals.ADMIN__FRIENDLY_NAME.getName(), String.class, null, TEST_PROVIDER,
-                    Map.of("value", TEST_PROVIDER, "timestamp", now), now);
+                    Map.of("timestamp", now), now);
             Mockito.verify(accumulator).metadataValueUpdate(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER,
                     ProviderPackage.Literals.PROVIDER__ADMIN.getName(),
                     ProviderPackage.Literals.ADMIN__FRIENDLY_NAME.getName(), null,
-                    Map.of("value", TEST_PROVIDER, "timestamp", now), now);
+                    Map.of("timestamp", now), now);
             HashMap<String, Object> map = new HashMap<>();
-            map.put("value", null);
             map.put("timestamp", now);
             Mockito.verify(accumulator).addResource(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER,
                     ProviderPackage.Literals.PROVIDER__ADMIN.getName(),
@@ -194,30 +193,27 @@ public class SubscriptionTest {
             Mockito.verify(accumulator).resourceValueUpdate(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER,
                     ProviderPackage.Literals.PROVIDER__ADMIN.getName(),
                     ProviderPackage.Literals.ADMIN__MODEL_PACKAGE_URI.getName(), String.class, null,
-                    model.getEPackage().getNsURI(), Map.of("value", TEST_MODEL_PKG, "timestamp", now), now);
+                    model.getEPackage().getNsURI(), Map.of("timestamp", now), now);
             Mockito.verify(accumulator).resourceValueUpdate(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER,
                     ProviderPackage.Literals.PROVIDER__ADMIN.getName(), ProviderPackage.Literals.ADMIN__MODEL.getName(),
-                    String.class, null, EMFUtil.getModelName(model), Map.of("value", TEST_MODEL, "timestamp", now),
+                    String.class, null, EMFUtil.getModelName(model), Map.of("timestamp", now),
                     now);
             Mockito.verify(accumulator).metadataValueUpdate(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER,
                     ProviderPackage.Literals.PROVIDER__ADMIN.getName(),
                     ProviderPackage.Literals.ADMIN__MODEL_PACKAGE_URI.getName(), null,
-                    Map.of("value", model.getEPackage().getNsURI(), "timestamp", now), now);
+                    Map.of("timestamp", now), now);
             Mockito.verify(accumulator).metadataValueUpdate(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER,
                     ProviderPackage.Literals.PROVIDER__ADMIN.getName(), ProviderPackage.Literals.ADMIN__MODEL.getName(),
-                    null, Map.of("value", EMFUtil.getModelName(model), "timestamp", now), now);
+                    null, Map.of("timestamp", now), now);
 
             Mockito.verify(accumulator).addService(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER, TEST_SERVICE);
             Mockito.verify(accumulator).addService(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER, TEST_SERVICE);
-            // TODO - this is missing
             Mockito.verify(accumulator).addResource(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER, TEST_SERVICE,
                     TEST_RESOURCE);
             Mockito.verify(accumulator).resourceValueUpdate(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER, TEST_SERVICE,
-                    TEST_RESOURCE, String.class, null, TEST_VALUE, Map.of("value", TEST_VALUE, "timestamp", now), now);
-            // TODO - the value is in here, which is surprising, as is the timestamp being a
-            // date
+                    TEST_RESOURCE, String.class, null, TEST_VALUE, Map.of("timestamp", now), now);
             Mockito.verify(accumulator).metadataValueUpdate(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER, TEST_SERVICE,
-                    TEST_RESOURCE, null, Map.of("value", TEST_VALUE, "timestamp", now), now);
+                    TEST_RESOURCE, null, Map.of("timestamp", now), now);
 
             Mockito.verifyNoMoreInteractions(accumulator);
         }
@@ -254,13 +250,12 @@ public class SubscriptionTest {
             Mockito.verify(accumulator).resourceValueUpdate(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER,
                     ProviderPackage.Literals.PROVIDER__ADMIN.getName(),
                     ProviderPackage.Literals.ADMIN__FRIENDLY_NAME.getName(), String.class, null, TEST_PROVIDER,
-                    Map.of("value", TEST_PROVIDER, "timestamp", before), before);
+                    Map.of("timestamp", before), before);
             Mockito.verify(accumulator).metadataValueUpdate(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER,
                     ProviderPackage.Literals.PROVIDER__ADMIN.getName(),
                     ProviderPackage.Literals.ADMIN__FRIENDLY_NAME.getName(), null,
-                    Map.of("value", TEST_PROVIDER, "timestamp", before), before);
+                    Map.of("timestamp", before), before);
             HashMap<String, Object> map = new HashMap<>();
-            map.put("value", null);
             map.put("timestamp", before);
             Mockito.verify(accumulator).addResource(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER,
                     ProviderPackage.Literals.PROVIDER__ADMIN.getName(),
@@ -280,18 +275,17 @@ public class SubscriptionTest {
             Mockito.verify(accumulator).resourceValueUpdate(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER,
                     ProviderPackage.Literals.PROVIDER__ADMIN.getName(),
                     ProviderPackage.Literals.ADMIN__MODEL_PACKAGE_URI.getName(), String.class, null,
-                    model.getEPackage().getNsURI(), Map.of("value", TEST_MODEL_PKG, "timestamp", before), before);
+                    model.getEPackage().getNsURI(), Map.of("timestamp", before), before);
             Mockito.verify(accumulator).resourceValueUpdate(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER,
                     ProviderPackage.Literals.PROVIDER__ADMIN.getName(), ProviderPackage.Literals.ADMIN__MODEL.getName(),
-                    String.class, null, EMFUtil.getModelName(model), Map.of("value", TEST_MODEL, "timestamp", before),
-                    before);
+                    String.class, null, EMFUtil.getModelName(model), Map.of("timestamp", before), before);
             Mockito.verify(accumulator).metadataValueUpdate(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER,
                     ProviderPackage.Literals.PROVIDER__ADMIN.getName(),
                     ProviderPackage.Literals.ADMIN__MODEL_PACKAGE_URI.getName(), null,
-                    Map.of("value", model.getEPackage().getNsURI(), "timestamp", before), before);
+                    Map.of("timestamp", before), before);
             Mockito.verify(accumulator).metadataValueUpdate(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER,
                     ProviderPackage.Literals.PROVIDER__ADMIN.getName(), ProviderPackage.Literals.ADMIN__MODEL.getName(),
-                    null, Map.of("value", EMFUtil.getModelName(model), "timestamp", before), before);
+                    null, Map.of("timestamp", before), before);
 
             Mockito.verify(accumulator).addService(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER, TEST_SERVICE);
             Mockito.verify(accumulator).addResource(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER, TEST_SERVICE,
@@ -299,16 +293,16 @@ public class SubscriptionTest {
             Mockito.verify(accumulator).addResource(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER, TEST_SERVICE,
                     TEST_RESOURCE_2);
             Mockito.verify(accumulator).resourceValueUpdate(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER, TEST_SERVICE,
-                    TEST_RESOURCE, String.class, null, TEST_VALUE, Map.of("value", TEST_VALUE, "timestamp", before),
+                    TEST_RESOURCE, String.class, null, TEST_VALUE, Map.of("timestamp", before),
                     before);
             Mockito.verify(accumulator).resourceValueUpdate(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER, TEST_SERVICE,
-                    TEST_RESOURCE_2, String.class, null, TEST_VALUE, Map.of("value", TEST_VALUE, "timestamp", now),
+                    TEST_RESOURCE_2, String.class, null, TEST_VALUE, Map.of("timestamp", now),
                     now);
 
             Mockito.verify(accumulator).metadataValueUpdate(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER, TEST_SERVICE,
-                    TEST_RESOURCE, null, Map.of("value", TEST_VALUE, "timestamp", before), before);
+                    TEST_RESOURCE, null, Map.of("timestamp", before), before);
             Mockito.verify(accumulator).metadataValueUpdate(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER, TEST_SERVICE,
-                    TEST_RESOURCE_2, null, Map.of("value", TEST_VALUE, "timestamp", now), now);
+                    TEST_RESOURCE_2, null, Map.of("timestamp", now), now);
 
             Mockito.verifyNoMoreInteractions(accumulator);
         }
@@ -346,13 +340,12 @@ public class SubscriptionTest {
             Mockito.verify(accumulator).resourceValueUpdate(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER,
                     ProviderPackage.Literals.PROVIDER__ADMIN.getName(),
                     ProviderPackage.Literals.ADMIN__FRIENDLY_NAME.getName(), String.class, null, TEST_PROVIDER,
-                    Map.of("value", TEST_PROVIDER, "timestamp", before), before);
+                    Map.of("timestamp", before), before);
             Mockito.verify(accumulator).metadataValueUpdate(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER,
                     ProviderPackage.Literals.PROVIDER__ADMIN.getName(),
                     ProviderPackage.Literals.ADMIN__FRIENDLY_NAME.getName(), null,
-                    Map.of("value", TEST_PROVIDER, "timestamp", before), before);
+                    Map.of("timestamp", before), before);
             HashMap<String, Object> map = new HashMap<>();
-            map.put("value", null);
             map.put("timestamp", before);
             Mockito.verify(accumulator).addResource(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER,
                     ProviderPackage.Literals.PROVIDER__ADMIN.getName(),
@@ -372,18 +365,18 @@ public class SubscriptionTest {
             Mockito.verify(accumulator).resourceValueUpdate(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER,
                     ProviderPackage.Literals.PROVIDER__ADMIN.getName(),
                     ProviderPackage.Literals.ADMIN__MODEL_PACKAGE_URI.getName(), String.class, null,
-                    model.getEPackage().getNsURI(), Map.of("value", TEST_MODEL_PKG, "timestamp", before), before);
+                    model.getEPackage().getNsURI(), Map.of("timestamp", before), before);
             Mockito.verify(accumulator).resourceValueUpdate(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER,
                     ProviderPackage.Literals.PROVIDER__ADMIN.getName(), ProviderPackage.Literals.ADMIN__MODEL.getName(),
-                    String.class, null, EMFUtil.getModelName(model), Map.of("value", TEST_MODEL, "timestamp", before),
+                    String.class, null, EMFUtil.getModelName(model), Map.of("timestamp", before),
                     before);
             Mockito.verify(accumulator).metadataValueUpdate(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER,
                     ProviderPackage.Literals.PROVIDER__ADMIN.getName(),
                     ProviderPackage.Literals.ADMIN__MODEL_PACKAGE_URI.getName(), null,
-                    Map.of("value", model.getEPackage().getNsURI(), "timestamp", before), before);
+                    Map.of("timestamp", before), before);
             Mockito.verify(accumulator).metadataValueUpdate(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER,
                     ProviderPackage.Literals.PROVIDER__ADMIN.getName(), ProviderPackage.Literals.ADMIN__MODEL.getName(),
-                    null, Map.of("value", EMFUtil.getModelName(model), "timestamp", before), before);
+                    null, Map.of("timestamp", before), before);
 
             Mockito.verify(accumulator).addService(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER, TEST_SERVICE);
             Mockito.verify(accumulator).addService(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER, TEST_SERVICE_2);
@@ -392,16 +385,16 @@ public class SubscriptionTest {
             Mockito.verify(accumulator).addResource(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER, TEST_SERVICE_2,
                     TEST_RESOURCE_2);
             Mockito.verify(accumulator).resourceValueUpdate(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER, TEST_SERVICE,
-                    TEST_RESOURCE, String.class, null, TEST_VALUE, Map.of("value", TEST_VALUE, "timestamp", before),
+                    TEST_RESOURCE, String.class, null, TEST_VALUE, Map.of("timestamp", before),
                     before);
             Mockito.verify(accumulator).resourceValueUpdate(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER, TEST_SERVICE_2,
-                    TEST_RESOURCE_2, String.class, null, TEST_VALUE_2, Map.of("value", TEST_VALUE_2, "timestamp", now),
+                    TEST_RESOURCE_2, String.class, null, TEST_VALUE_2, Map.of("timestamp", now),
                     now);
 
             Mockito.verify(accumulator).metadataValueUpdate(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER, TEST_SERVICE,
-                    TEST_RESOURCE, null, Map.of("value", TEST_VALUE, "timestamp", before), before);
+                    TEST_RESOURCE, null, Map.of("timestamp", before), before);
             Mockito.verify(accumulator).metadataValueUpdate(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER, TEST_SERVICE_2,
-                    TEST_RESOURCE_2, null, Map.of("value", TEST_VALUE_2, "timestamp", now), now);
+                    TEST_RESOURCE_2, null, Map.of("timestamp", now), now);
 
             Mockito.verifyNoMoreInteractions(accumulator);
         }
@@ -409,7 +402,6 @@ public class SubscriptionTest {
         private static final String METADATA_KEY = "key";
         private static final String METADATA_VALUE = "value";
 
-        @SuppressWarnings("serial")
         @Test
         void basicTestWithMetadata() {
 
@@ -438,13 +430,12 @@ public class SubscriptionTest {
             Mockito.verify(accumulator).resourceValueUpdate(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER,
                     ProviderPackage.Literals.PROVIDER__ADMIN.getName(),
                     ProviderPackage.Literals.ADMIN__FRIENDLY_NAME.getName(), String.class, null, TEST_PROVIDER,
-                    Map.of("value", TEST_PROVIDER, "timestamp", now), now);
+                    Map.of("timestamp", now), now);
             Mockito.verify(accumulator).metadataValueUpdate(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER,
                     ProviderPackage.Literals.PROVIDER__ADMIN.getName(),
                     ProviderPackage.Literals.ADMIN__FRIENDLY_NAME.getName(), null,
-                    Map.of("value", TEST_PROVIDER, "timestamp", now), now);
+                    Map.of("timestamp", now), now);
             HashMap<String, Object> map = new HashMap<>();
-            map.put("value", null);
             map.put("timestamp", now);
             Mockito.verify(accumulator).addResource(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER,
                     ProviderPackage.Literals.PROVIDER__ADMIN.getName(),
@@ -464,18 +455,18 @@ public class SubscriptionTest {
             Mockito.verify(accumulator).resourceValueUpdate(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER,
                     ProviderPackage.Literals.PROVIDER__ADMIN.getName(),
                     ProviderPackage.Literals.ADMIN__MODEL_PACKAGE_URI.getName(), String.class, null,
-                    model.getEPackage().getNsURI(), Map.of("value", TEST_MODEL_PKG, "timestamp", now), now);
+                    model.getEPackage().getNsURI(), Map.of("timestamp", now), now);
             Mockito.verify(accumulator).resourceValueUpdate(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER,
                     ProviderPackage.Literals.PROVIDER__ADMIN.getName(), ProviderPackage.Literals.ADMIN__MODEL.getName(),
-                    String.class, null, EMFUtil.getModelName(model), Map.of("value", TEST_MODEL, "timestamp", now),
+                    String.class, null, EMFUtil.getModelName(model), Map.of("timestamp", now),
                     now);
             Mockito.verify(accumulator).metadataValueUpdate(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER,
                     ProviderPackage.Literals.PROVIDER__ADMIN.getName(),
                     ProviderPackage.Literals.ADMIN__MODEL_PACKAGE_URI.getName(), null,
-                    Map.of("value", model.getEPackage().getNsURI(), "timestamp", now), now);
+                    Map.of("timestamp", now), now);
             Mockito.verify(accumulator).metadataValueUpdate(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER,
                     ProviderPackage.Literals.PROVIDER__ADMIN.getName(), ProviderPackage.Literals.ADMIN__MODEL.getName(),
-                    null, Map.of("value", EMFUtil.getModelName(model), "timestamp", now), now);
+                    null, Map.of("timestamp", now), now);
 
             Mockito.verify(accumulator).addService(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER, TEST_SERVICE);
             Mockito.verify(accumulator).addService(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER, TEST_SERVICE);
@@ -483,9 +474,7 @@ public class SubscriptionTest {
                     TEST_RESOURCE);
             Mockito.verify(accumulator).resourceValueUpdate(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER, TEST_SERVICE,
                     TEST_RESOURCE, String.class, null, TEST_VALUE,
-                    Map.of("value", TEST_VALUE, "timestamp", now, METADATA_KEY, METADATA_VALUE), now);
-            // TODO - the value is in here, which is surprising, as is the timestamp being a
-            // date
+                    Map.of("timestamp", now, METADATA_KEY, METADATA_VALUE), now);
             Mockito.verify(accumulator).metadataValueUpdate(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER, TEST_SERVICE,
                     TEST_RESOURCE, new HashMap<String, Object>() {
                         {
@@ -501,10 +490,9 @@ public class SubscriptionTest {
                     TEST_RESOURCE, new HashMap<String, Object>() {
                         {
                             put(METADATA_KEY, METADATA_VALUE);
-                            put("value", null);
                             put("timestamp", null);
                         }
-                    }, Map.of(METADATA_KEY, METADATA_VALUE, "value", TEST_VALUE, "timestamp", now), now);
+                    }, Map.of(METADATA_KEY, METADATA_VALUE, "timestamp", now), now);
 
             Mockito.verifyNoMoreInteractions(accumulator);
         }
@@ -715,11 +703,11 @@ public class SubscriptionTest {
                     "foo2");
             Mockito.verify(accumulator).resourceValueUpdate(ePackage.getNsURI(), modelName, provider.getId(),
                     "testService1", "foo2", String.class, null, "somethingElse",
-                    Map.of("value", "somethingElse", "timestamp", newMetadata.getTimestamp()),
+                    Map.of("timestamp", newMetadata.getTimestamp()),
                     newMetadata.getTimestamp());
             Mockito.verify(accumulator).metadataValueUpdate(ePackage.getNsURI(), modelName, provider.getId(),
                     "testService1", "foo2", null,
-                    Map.of("value", "somethingElse", "timestamp", newMetadata.getTimestamp()),
+                    Map.of("timestamp", newMetadata.getTimestamp()),
                     newMetadata.getTimestamp());
             Mockito.verifyNoMoreInteractions(accumulator);
         }
@@ -776,10 +764,10 @@ public class SubscriptionTest {
 
             Mockito.verify(accumulator).resourceValueUpdate(ePackage.getNsURI(), modelName, provider.getId(),
                     "testService1", "foo", String.class, "foo", "foo2",
-                    Map.of("value", "foo2", "timestamp", curMetadata.getTimestamp()), curMetadata.getTimestamp());
+                    Map.of("timestamp", curMetadata.getTimestamp()), curMetadata.getTimestamp());
             Mockito.verify(accumulator).metadataValueUpdate(ePackage.getNsURI(), modelName, provider.getId(),
-                    "testService1", "foo", Map.of("value", "foo", "timestamp", oldMetadata.getTimestamp()),
-                    Map.of("value", "foo2", "timestamp", curMetadata.getTimestamp()), curMetadata.getTimestamp());
+                    "testService1", "foo", Map.of("timestamp", oldMetadata.getTimestamp()),
+                    Map.of("timestamp", curMetadata.getTimestamp()), curMetadata.getTimestamp());
             Mockito.verifyNoMoreInteractions(accumulator);
         }
 
@@ -852,11 +840,11 @@ public class SubscriptionTest {
                     "foo2");
             Mockito.verify(accumulator).resourceValueUpdate(ePackage.getNsURI(), modelName, provider.getId(),
                     "testService1", "foo2", String.class, null, "somethingElse", Map.of("test.meta.1", "some Test",
-                            "value", "somethingElse", "timestamp", newMetadata.getTimestamp()),
+                            "timestamp", newMetadata.getTimestamp()),
                     newMetadata.getTimestamp());
             Mockito.verify(accumulator).metadataValueUpdate(ePackage.getNsURI(), modelName, provider.getId(),
-                    "testService1", "foo2", null, Map.of("test.meta.1", "some Test", "value", "somethingElse",
-                            "timestamp", newMetadata.getTimestamp()),
+                    "testService1", "foo2", null, Map.of("test.meta.1", "some Test", "timestamp",
+                            newMetadata.getTimestamp()),
                     newMetadata.getTimestamp());
             Mockito.verifyNoMoreInteractions(accumulator);
         }
@@ -932,12 +920,12 @@ public class SubscriptionTest {
 
             Mockito.verify(accumulator).resourceValueUpdate(ePackage.getNsURI(), modelName, provider.getId(),
                     "testService1", "foo", String.class, "foo", "foo2", Map.of("test.meta.1", "some Test",
-                            "test.meta.2", 2, "value", "foo2", "timestamp", curMetadata.getTimestamp()),
+                            "test.meta.2", 2, "timestamp", curMetadata.getTimestamp()),
                     curMetadata.getTimestamp());
             Mockito.verify(accumulator).metadataValueUpdate(
                     ePackage.getNsURI(), modelName, provider.getId(), "testService1", "foo",
-                    Map.of("value", "foo", "timestamp", oldMetadataTimestampToCompare), Map.of("test.meta.1",
-                            "some Test", "test.meta.2", 2, "value", "foo2", "timestamp", curMetadata.getTimestamp()),
+                    Map.of("timestamp", oldMetadataTimestampToCompare), Map.of("test.meta.1",
+                            "some Test", "test.meta.2", 2, "timestamp", curMetadata.getTimestamp()),
                     curMetadata.getTimestamp());
             Mockito.verifyNoMoreInteractions(accumulator);
         }
@@ -996,11 +984,11 @@ public class SubscriptionTest {
                     "annotated");
             Mockito.verify(accumulator).resourceValueUpdate(ePackage.getNsURI(), modelName, provider.getId(),
                     "testService2", "annotated", String.class, null, "avalue", Map.of("test", "testMetadata", "test2",
-                            "testMetadata2", "value", "avalue", "timestamp", curMetadata.getTimestamp()),
+                            "testMetadata2", "timestamp", curMetadata.getTimestamp()),
                     curMetadata.getTimestamp());
             Mockito.verify(accumulator).metadataValueUpdate(ePackage.getNsURI(), modelName, provider.getId(),
-                    "testService2", "annotated", null, Map.of("test", "testMetadata", "test2", "testMetadata2", "value",
-                            "avalue", "timestamp", curMetadata.getTimestamp()),
+                    "testService2", "annotated", null, Map.of("test", "testMetadata", "test2", "testMetadata2",
+                            "timestamp", curMetadata.getTimestamp()),
                     curMetadata.getTimestamp());
             Mockito.verifyNoMoreInteractions(accumulator);
         }
@@ -1078,11 +1066,11 @@ public class SubscriptionTest {
                     "annotated");
             Mockito.verify(accumulator).resourceValueUpdate(ePackage.getNsURI(), modelName, provider.getId(),
                     "testService2", "annotated", String.class, null, "avalue", Map.of("test", mv.getValue(), "test2",
-                            "testMetadata2", "value", "avalue", "timestamp", curMetadata.getTimestamp()),
+                            "testMetadata2", "timestamp", curMetadata.getTimestamp()),
                     curMetadata.getTimestamp());
             Mockito.verify(accumulator).metadataValueUpdate(ePackage.getNsURI(), modelName, provider.getId(),
-                    "testService2", "annotated", null, Map.of("test", mv.getValue(), "test2", "testMetadata2", "value",
-                            "avalue", "timestamp", curMetadata.getTimestamp()),
+                    "testService2", "annotated", null, Map.of("test", mv.getValue(), "test2", "testMetadata2",
+                            "timestamp", curMetadata.getTimestamp()),
                     curMetadata.getTimestamp());
             Mockito.verifyNoMoreInteractions(accumulator);
         }
@@ -1160,13 +1148,13 @@ public class SubscriptionTest {
 
             Mockito.verify(accumulator).resourceValueUpdate(ePackage.getNsURI(), modelName, provider.getId(),
                     "testService1", "foo", String.class, "foo", "foo",
-                    Map.of("test.meta.1", "some Test", "value", "foo", "timestamp", curMetadata.getTimestamp()),
+                    Map.of("test.meta.1", "some Test", "timestamp", curMetadata.getTimestamp()),
                     curMetadata.getTimestamp());
             Mockito.verify(accumulator).metadataValueUpdate(ePackage.getNsURI(), modelName, provider.getId(),
                     "testService1", "foo",
-                    Map.of("test.meta.1", "some Test", "test.meta.2", 2, "value", "foo", "timestamp",
+                    Map.of("test.meta.1", "some Test", "test.meta.2", 2, "timestamp",
                             oldMetadataTimestampToCompare),
-                    Map.of("test.meta.1", "some Test", "value", "foo", "timestamp", curMetadata.getTimestamp()),
+                    Map.of("test.meta.1", "some Test", "timestamp", curMetadata.getTimestamp()),
                     curMetadata.getTimestamp());
             Mockito.verifyNoMoreInteractions(accumulator);
         }
@@ -1570,9 +1558,9 @@ public class SubscriptionTest {
         Instant time = getTimestampForService(service, attribute);
         Mockito.verify(accumulator).resourceValueUpdate(provider.eClass().getEPackage().getNsURI(), modelName,
                 provider.getId(), serviceName, attribute.getName(), attribute.getEType().getInstanceClass(), null,
-                value, Map.of("value", value, "timestamp", time), time);
+                value, Map.of("timestamp", time), time);
         Mockito.verify(accumulator).metadataValueUpdate(provider.eClass().getEPackage().getNsURI(), modelName,
-                provider.getId(), serviceName, attribute.getName(), null, Map.of("value", value, "timestamp", time),
+                provider.getId(), serviceName, attribute.getName(), null, Map.of("timestamp", time),
                 time);
     }
 
@@ -1585,7 +1573,7 @@ public class SubscriptionTest {
                 Mockito.any());
         Mockito.verify(accumulator).metadataValueUpdate(provider.eClass().getEPackage().getNsURI(), modelName,
                 provider.getId(), oldService.eContainingFeature().getName(), attribute.getName(),
-                Map.of("value", oldService.eGet(attribute), "timestamp", getTimestampForService(oldService, attribute)),
+                Map.of("timestamp", getTimestampForService(oldService, attribute)),
                 null, Mockito.any());
         Mockito.verify(accumulator).removeResource(provider.eClass().getEPackage().getNsURI(), modelName,
                 provider.getId(), oldService.eContainingFeature().getName(), attribute.getName());

--- a/core/impl/src/test/java/org/eclipse/sensinact/core/notification/impl/NotificationSenderTest.java
+++ b/core/impl/src/test/java/org/eclipse/sensinact/core/notification/impl/NotificationSenderTest.java
@@ -578,30 +578,6 @@ class NotificationSenderTest {
 
             assertTrue(thrown.getMessage().contains("out of temporal order"), "Wrong message: " + thrown.getMessage());
         }
-
-        @Test
-        void testCollectionValueIsSnapshotted() {
-            Instant now = Instant.now();
-
-            List<String> mutableNew = new java.util.ArrayList<>(List.of("a", "b"));
-            List<String> mutableOld = new java.util.ArrayList<>(List.of("x"));
-
-            accumulator.resourceValueUpdate(MODEL_PKG, MODEL, PROVIDER, SERVICE, RESOURCE, List.class,
-                    mutableOld, mutableNew, null, now);
-
-            // Simulate concurrent EMF model mutation after registration
-            mutableNew.clear();
-            mutableOld.clear();
-
-            // Without snapshotting, the notification would carry the mutated (empty) lists.
-            // With snapshotting, the original values ["a","b"] and ["x"] must be preserved.
-            accumulator.completeAndSend();
-
-            Mockito.verify(bus).deliver(eq("DATA/" + MODEL + "/" + PROVIDER + "/" + SERVICE + "/" + RESOURCE),
-                    argThat(isValueNotificationWith(PROVIDER, SERVICE, RESOURCE, List.class,
-                            List.of("x"), List.of("a", "b"), null, now)));
-            Mockito.verifyNoMoreInteractions(bus);
-        }
     }
 
     @Nested


### PR DESCRIPTION
The digital twin can contain multi-valued resources. These multi-values can leak in several ways:

* Getting the resource
* Value notifications
* Metadata notifications

This commit ensures that the multi-valued content is copied before exposing it. It also removes the value from the metadata map as it has no business being there.