### PR TITLE
Fix for issue #745 - tidy up metadata notifications

### DIFF
--- a/core/api/src/main/java/org/eclipse/sensinact/core/notification/ResourceMetaDataNotification.java
+++ b/core/api/src/main/java/org/eclipse/sensinact/core/notification/ResourceMetaDataNotification.java
@@ -25,7 +25,7 @@ import java.util.Objects;
  * METADATA/&lt;model&gt;/&lt;provider&gt;/&lt;service&gt;/&lt;resource&gt;
  */
 public record ResourceMetaDataNotification(String modelPackageUri, String model, String provider,
-        String service, String resource, Map<String, Object> oldValues,
+        String service, String resource, Object data, Map<String, Object> oldValues,
         Map<String, Object> newValues, Instant timestamp) implements ResourceNotification {
 
     @Override

--- a/core/impl/src/main/java/org/eclipse/sensinact/core/model/nexus/ModelNexus.java
+++ b/core/impl/src/main/java/org/eclipse/sensinact/core/model/nexus/ModelNexus.java
@@ -440,24 +440,20 @@ public class ModelNexus {
         ResourceValueMetadata metadata = service.getMetadata().get(resourceFeature);
 
         Map<String, Object> oldMetaData = null;
-        Object oldValue = service.eGet(resourceFeature);
-        // Holds an immutable snapshot of the value if it is a {@link Collection}
-        // to prevent race conditions when the underlying EMF list is later modified.
-        if(oldValue instanceof Collection<?> c) {
-            oldValue = List.copyOf(c);
-        }
+        Object oldValue = doGetResourceValue(service, resourceFeature);
         if (metadata != null) {
             oldMetaData = EMFUtil.toMetadataAttributesToMap(metadata, resourceFeature);
         }
+        boolean newResource = false;
         if(metadata == null || metadata.getTimestamp() == null) {
             // New resource addition
             accumulator.addResource(packageUri, modelName, providerName, serviceName, resourceFeature.getName());
+            newResource = true;
         }
 
         // Allow an update if the resource didn't exist or if the update timestamp is
         // equal to or after the one of the current value
-        if (metadata == null || metadata.getTimestamp() == null
-                || !metadata.getTimestamp().isAfter(metaTimestamp.plusMillis(1))) {
+        if (newResource || (metaTimestamp.compareTo(metadata.getTimestamp()) >= 0)) {
             EClassifier resourceType = resourceFeature.getEType();
 
             if (metadata == null) {
@@ -515,11 +511,23 @@ public class ModelNexus {
 
             accumulator.resourceValueUpdate(packageUri, modelName, providerName, serviceName, resourceFeature.getName(),
                     resourceType.getInstanceClass(), oldValue, storedData, newMetaData, metaTimestamp);
-            accumulator.metadataValueUpdate(packageUri, modelName, providerName, serviceName, resourceFeature.getName(),
-                    oldMetaData, newMetaData, timestamp);
+            if (newResource) {
+                accumulator.metadataValueUpdate(packageUri, modelName, providerName, serviceName, resourceFeature.getName(),
+                        storedData, oldMetaData, newMetaData, timestamp);
+            }
         } else {
             return;
         }
+    }
+
+    private Object doGetResourceValue(Service service, EStructuralFeature resourceFeature) {
+        Object oldValue = service.eGet(resourceFeature);
+        // Holds an immutable snapshot of the value if it is a {@link Collection}
+        // to prevent race conditions when the underlying EMF list is later modified.
+        if(oldValue instanceof Collection<?> c) {
+            oldValue = List.copyOf(c);
+        }
+        return oldValue;
     }
 
     /**
@@ -833,10 +841,11 @@ public class ModelNexus {
             EMFUtil.handleMetadataValue(fcm, timestamp, value);
         }
         Map<String, Object> newMetadata = EMFUtil.toMetadataAttributesToMap(metadata, resource);
+        Object dataValue = resource instanceof EStructuralFeature esf ? doGetResourceValue(svc, esf) : null;
 
         notificationAccumulator.get().metadataValueUpdate(provider.eClass().getEPackage().getNsURI(),
-                EMFUtil.getModelName(provider.eClass()), provider.getId(), serviceName, resource.getName(), oldMetadata,
-                newMetadata, timestamp);
+                EMFUtil.getModelName(provider.eClass()), provider.getId(), serviceName, resource.getName(),
+                dataValue, oldMetadata, newMetadata, timestamp);
     }
 
     public void unsetResourceMetadata(Provider provider, EStructuralFeature svcFeature, ETypedElement resource,
@@ -888,10 +897,10 @@ public class ModelNexus {
             return;
         }
         Map<String, Object> newMetadata = EMFUtil.toMetadataAttributesToMap(metadata, resource);
-
+        Object dataValue = resource instanceof EStructuralFeature esf ? doGetResourceValue(svc, esf) : null;
         notificationAccumulator.get().metadataValueUpdate(provider.eClass().getEPackage().getNsURI(),
-                EMFUtil.getModelName(provider.eClass()), provider.getId(), serviceName, resource.getName(), oldMetadata,
-                newMetadata, timestamp);
+                EMFUtil.getModelName(provider.eClass()), provider.getId(), serviceName, resource.getName(),
+                dataValue, oldMetadata, newMetadata, timestamp);
     }
 
     public Set<String> getModelNames() {

--- a/core/impl/src/main/java/org/eclipse/sensinact/core/model/nexus/emf/compare/EMFCompareUtil.java
+++ b/core/impl/src/main/java/org/eclipse/sensinact/core/model/nexus/emf/compare/EMFCompareUtil.java
@@ -314,17 +314,20 @@ public class EMFCompareUtil {
                 oldMetaData = EMFUtil.toMetadataAttributesToMap(originalMetadata, resource);
             }
 
-            Metadata updatedMetadata = updateMetadata(resource, newService, originalService, newTimestamp);
+            boolean updatedMetadata = updateMetadata(resource, newService, originalService, newTimestamp);
 
             originalService.eSet(resource, newValue);
 
-            Map<String, Object> newMetaData = EMFUtil.toMetadataAttributesToMap(updatedMetadata, resource);
+            Map<String, Object> newMetaData = EMFUtil.toMetadataAttributesToMap(
+                    originalService.getMetadata().get(resource), resource);
 
             accumulator.resourceValueUpdate(packageUri, modelName, providerName, serviceName, resource.getName(),
                     resource.getEType().getInstanceClass(), oldValue, newValue, newMetaData, newTimestamp);
 
-            accumulator.metadataValueUpdate(packageUri, modelName, providerName, serviceName, resource.getName(),
-                    oldMetaData, newMetaData, newTimestamp);
+            if (isNew || updatedMetadata) {
+                accumulator.metadataValueUpdate(packageUri, modelName, providerName, serviceName, resource.getName(),
+                        newValue, oldMetaData, newMetaData, newTimestamp);
+            }
 
             if (newValue == null) {
                 accumulator.removeResource(packageUri, modelName, providerName, serviceName, resource.getName());
@@ -333,26 +336,27 @@ public class EMFCompareUtil {
 
     }
 
-    private static ResourceValueMetadata updateMetadata(EStructuralFeature resource, Service newService,
+    private static boolean updateMetadata(EStructuralFeature resource, Service newService,
             Service originalService, Instant newTimestamp) {
         ResourceValueMetadata resourceMetadata = checkMetadata(originalService, resource);
         resourceMetadata.setTimestamp(newTimestamp);
         Metadata update = newService.getMetadata().get(resource);
+        boolean updated = false;
         if (update != null && update.eIsSet(ProviderPackage.Literals.METADATA__EXTRA)) {
-            updateExtraMetadata(update.getExtra(), resourceMetadata.getExtra(), newTimestamp);
+            updated = updateExtraMetadata(update.getExtra(), resourceMetadata.getExtra(), newTimestamp);
         }
 
-        return resourceMetadata;
+        return updated;
     }
 
-    private static void updateExtraMetadata(EMap<String, MetadataValue> extraNew,
+    private static boolean updateExtraMetadata(EMap<String, MetadataValue> extraNew,
             EMap<String, MetadataValue> extraOriginal, Instant newTimestamp) {
+        boolean updated = false;
         if (extraNew.isEmpty() && extraOriginal.isEmpty()) {
-            return;
+            return updated;
         }
-        Map<String, MetadataValue> toRemoveMap = new HashMap<>();
-        extraOriginal.forEach(e -> toRemoveMap.put(e.getKey(), e.getValue()));
-        extraNew.forEach(e -> {
+        Map<String, MetadataValue> toRemoveMap = new HashMap<>(extraOriginal.map());
+        for(Entry<String, MetadataValue> e : extraNew) {
             MetadataValue mv = e.getValue();
             MetadataValue original = toRemoveMap.remove(e.getKey());
             Instant timestamp = mv.getTimestamp() == null ? newTimestamp : mv.getTimestamp();
@@ -362,12 +366,16 @@ public class EMFCompareUtil {
                     copy.setTimestamp(newTimestamp);
                 }
                 extraOriginal.put(e.getKey(), copy);
-            } else if (original.getTimestamp().plusMillis(1).isBefore(timestamp)) {
+                updated = true;
+            } else if (original.getTimestamp().isBefore(timestamp)) {
                 original.setValue(mv.getValue());
                 original.setTimestamp(timestamp);
+                updated = true;
             }
-        });
-        toRemoveMap.keySet().forEach(extraOriginal::removeKey);
+        }
+        updated |= !toRemoveMap.isEmpty();
+        extraOriginal.keySet().removeAll(toRemoveMap.keySet());
+        return updated;
     }
 
     private static Instant getNewTimestampFromMetadata(EStructuralFeature resource, Service service) {
@@ -397,8 +405,8 @@ public class EMFCompareUtil {
             accumulator.resourceValueUpdate(packageUri, model, providerName, serviceName, ea.getName(),
                     ea.getEAttributeType().getInstanceClass(), null, resourceValue, newMetaData,
                     metadata.getTimestamp());
-            accumulator.metadataValueUpdate(packageUri, model, providerName, serviceName, ea.getName(), null,
-                    newMetaData, metadata.getTimestamp());
+            accumulator.metadataValueUpdate(packageUri, model, providerName, serviceName, ea.getName(),
+                    resourceValue, null, newMetaData, metadata.getTimestamp());
         });
     }
 

--- a/core/impl/src/main/java/org/eclipse/sensinact/core/notification/impl/AbstractNotificationAccumulatorImpl.java
+++ b/core/impl/src/main/java/org/eclipse/sensinact/core/notification/impl/AbstractNotificationAccumulatorImpl.java
@@ -13,7 +13,6 @@
 package org.eclipse.sensinact.core.notification.impl;
 
 import java.time.Instant;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -50,10 +49,10 @@ public abstract class AbstractNotificationAccumulatorImpl implements Notificatio
     }
 
     protected ResourceMetaDataNotification createResourceMetaDataNotification(String modelPackageUri, String model, String provider,
-            String service, String resource, Map<String, Object> oldValues, Map<String, Object> newValues,
+            String service, String resource, Object data, Map<String, Object> oldValues, Map<String, Object> newValues,
             Instant timestamp) {
         return new ResourceMetaDataNotification(modelPackageUri, model, provider, service,
-                resource, oldValues, newValues, timestamp);
+                resource, data, oldValues, newValues, timestamp);
     }
 
     protected ResourceDataNotification createResourceDataNotification(String modelPackageUri, String model, String provider, String service,

--- a/core/impl/src/main/java/org/eclipse/sensinact/core/notification/impl/ImmediateNotificationAccumulator.java
+++ b/core/impl/src/main/java/org/eclipse/sensinact/core/notification/impl/ImmediateNotificationAccumulator.java
@@ -141,14 +141,14 @@ public class ImmediateNotificationAccumulator extends AbstractNotificationAccumu
      */
     @Override
     public void metadataValueUpdate(String modelPackageUri, String model, String provider, String service, String resource,
-            Map<String, Object> oldValues, Map<String, Object> newValues, Instant timestamp) {
+            Object data, Map<String, Object> oldValues, Map<String, Object> newValues, Instant timestamp) {
 
         Map<String, Object> nonNullOldValues = oldValues == null ? emptyMap() : oldValues;
         Map<String, Object> nonNullNewValues = newValues == null ? emptyMap() : newValues;
         Objects.requireNonNull(timestamp);
 
         ResourceMetaDataNotification rmn = createResourceMetaDataNotification(modelPackageUri, model, provider, service, resource,
-                nonNullOldValues, nonNullNewValues, timestamp);
+                data, nonNullOldValues, nonNullNewValues, timestamp);
 
         eventBus.deliver(rmn.getTopic(), rmn);
     }

--- a/core/impl/src/main/java/org/eclipse/sensinact/core/notification/impl/NotificationAccumulator.java
+++ b/core/impl/src/main/java/org/eclipse/sensinact/core/notification/impl/NotificationAccumulator.java
@@ -133,7 +133,7 @@ public interface NotificationAccumulator {
      *                                  {@link #completeAndSend()}
      */
     void metadataValueUpdate(String modelPackageUri, String model, String provider, String service, String resource,
-            Map<String, Object> oldValues, Map<String, Object> newValues, Instant timestamp);
+            Object data, Map<String, Object> oldValues, Map<String, Object> newValues, Instant timestamp);
 
     /**
      * Called to update a resource value. If multiple updates occur they will be

--- a/core/impl/src/main/java/org/eclipse/sensinact/core/notification/impl/NotificationAccumulatorImpl.java
+++ b/core/impl/src/main/java/org/eclipse/sensinact/core/notification/impl/NotificationAccumulatorImpl.java
@@ -216,7 +216,7 @@ public class NotificationAccumulatorImpl extends AbstractNotificationAccumulator
      */
     @Override
     public void metadataValueUpdate(String modelPackageUri, String model, String provider, String service, String resource,
-            Map<String, Object> oldValues, Map<String, Object> newValues, Instant timestamp) {
+            Object data, Map<String, Object> oldValues, Map<String, Object> newValues, Instant timestamp) {
         check();
 
         final Map<String, Object> nonNullOldValues = oldValues == null ? emptyMap() : oldValues;
@@ -258,7 +258,16 @@ public class NotificationAccumulatorImpl extends AbstractNotificationAccumulator
                             });
 
                     return List.of(createResourceMetaDataNotification(modelPackageUri, model, provider, service, resource,
-                            oldValuesToUse, newValuesToUse, timestampToUse));
+                            data, oldValuesToUse, newValuesToUse, timestampToUse));
+                });
+        notifications.computeIfPresent(new NotificationKey(provider, service, resource, ResourceDataNotification.class),
+                (k,v) -> {
+                    if(v.isEmpty()) {
+                        return v;
+                    }
+                    ResourceDataNotification rdn = (ResourceDataNotification) v.get(0);
+                    return List.of(createResourceDataNotification(modelPackageUri, model, provider, service, resource,
+                            rdn.type(), rdn.oldValue(), rdn.newValue(), newValues, rdn.timestamp()));
                 });
     }
 
@@ -299,6 +308,16 @@ public class NotificationAccumulatorImpl extends AbstractNotificationAccumulator
                     }
                     return List.of(createResourceDataNotification(modelPackageUri, model, provider, service, resource, type,
                             oldValueToUse, newValue, metadata, timestamp));
+                });
+        notifications.computeIfPresent(new NotificationKey(provider, service, resource, ResourceMetaDataNotification.class),
+                (k,v) -> {
+                    if(v.isEmpty()) {
+                        return v;
+                    } else {
+                        ResourceMetaDataNotification rmdn = (ResourceMetaDataNotification) v.get(0);
+                        return List.of(createResourceMetaDataNotification(modelPackageUri, model, provider, service, resource,
+                                newValue, rmdn.oldValues(), metadata, timestamp));
+                    }
                 });
     }
 

--- a/core/impl/src/test/java/org/eclipse/sensinact/core/model/nexus/SubscriptionTest.java
+++ b/core/impl/src/test/java/org/eclipse/sensinact/core/model/nexus/SubscriptionTest.java
@@ -171,7 +171,7 @@ public class SubscriptionTest {
                     Map.of("timestamp", now), now);
             Mockito.verify(accumulator).metadataValueUpdate(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER,
                     ProviderPackage.Literals.PROVIDER__ADMIN.getName(),
-                    ProviderPackage.Literals.ADMIN__FRIENDLY_NAME.getName(), null,
+                    ProviderPackage.Literals.ADMIN__FRIENDLY_NAME.getName(), TEST_PROVIDER, null,
                     Map.of("timestamp", now), now);
             HashMap<String, Object> map = new HashMap<>();
             map.put("timestamp", now);
@@ -183,7 +183,7 @@ public class SubscriptionTest {
                     ProviderPackage.Literals.ADMIN__DESCRIPTION.getName(), String.class, null, null, map, now);
             Mockito.verify(accumulator).metadataValueUpdate(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER,
                     ProviderPackage.Literals.PROVIDER__ADMIN.getName(),
-                    ProviderPackage.Literals.ADMIN__DESCRIPTION.getName(), null, map, now);
+                    ProviderPackage.Literals.ADMIN__DESCRIPTION.getName(), null, null, map, now);
             Mockito.verify(accumulator).addResource(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER,
                     ProviderPackage.Literals.PROVIDER__ADMIN.getName(),
                     ProviderPackage.Literals.ADMIN__MODEL_PACKAGE_URI.getName());
@@ -200,11 +200,11 @@ public class SubscriptionTest {
                     now);
             Mockito.verify(accumulator).metadataValueUpdate(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER,
                     ProviderPackage.Literals.PROVIDER__ADMIN.getName(),
-                    ProviderPackage.Literals.ADMIN__MODEL_PACKAGE_URI.getName(), null,
-                    Map.of("timestamp", now), now);
+                    ProviderPackage.Literals.ADMIN__MODEL_PACKAGE_URI.getName(), TEST_MODEL_PKG,
+                    null, Map.of("timestamp", now), now);
             Mockito.verify(accumulator).metadataValueUpdate(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER,
                     ProviderPackage.Literals.PROVIDER__ADMIN.getName(), ProviderPackage.Literals.ADMIN__MODEL.getName(),
-                    null, Map.of("timestamp", now), now);
+                    TEST_MODEL, null, Map.of("timestamp", now), now);
 
             Mockito.verify(accumulator).addService(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER, TEST_SERVICE);
             Mockito.verify(accumulator).addService(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER, TEST_SERVICE);
@@ -213,7 +213,7 @@ public class SubscriptionTest {
             Mockito.verify(accumulator).resourceValueUpdate(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER, TEST_SERVICE,
                     TEST_RESOURCE, String.class, null, TEST_VALUE, Map.of("timestamp", now), now);
             Mockito.verify(accumulator).metadataValueUpdate(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER, TEST_SERVICE,
-                    TEST_RESOURCE, null, Map.of("timestamp", now), now);
+                    TEST_RESOURCE, TEST_VALUE, null, Map.of("timestamp", now), now);
 
             Mockito.verifyNoMoreInteractions(accumulator);
         }
@@ -253,7 +253,7 @@ public class SubscriptionTest {
                     Map.of("timestamp", before), before);
             Mockito.verify(accumulator).metadataValueUpdate(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER,
                     ProviderPackage.Literals.PROVIDER__ADMIN.getName(),
-                    ProviderPackage.Literals.ADMIN__FRIENDLY_NAME.getName(), null,
+                    ProviderPackage.Literals.ADMIN__FRIENDLY_NAME.getName(), TEST_PROVIDER, null,
                     Map.of("timestamp", before), before);
             HashMap<String, Object> map = new HashMap<>();
             map.put("timestamp", before);
@@ -265,7 +265,7 @@ public class SubscriptionTest {
                     ProviderPackage.Literals.ADMIN__DESCRIPTION.getName(), String.class, null, null, map, before);
             Mockito.verify(accumulator).metadataValueUpdate(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER,
                     ProviderPackage.Literals.PROVIDER__ADMIN.getName(),
-                    ProviderPackage.Literals.ADMIN__DESCRIPTION.getName(), null, map, before);
+                    ProviderPackage.Literals.ADMIN__DESCRIPTION.getName(), null, null, map, before);
             Mockito.verify(accumulator).addResource(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER,
                     ProviderPackage.Literals.PROVIDER__ADMIN.getName(),
                     ProviderPackage.Literals.ADMIN__MODEL_PACKAGE_URI.getName());
@@ -281,11 +281,11 @@ public class SubscriptionTest {
                     String.class, null, EMFUtil.getModelName(model), Map.of("timestamp", before), before);
             Mockito.verify(accumulator).metadataValueUpdate(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER,
                     ProviderPackage.Literals.PROVIDER__ADMIN.getName(),
-                    ProviderPackage.Literals.ADMIN__MODEL_PACKAGE_URI.getName(), null,
-                    Map.of("timestamp", before), before);
+                    ProviderPackage.Literals.ADMIN__MODEL_PACKAGE_URI.getName(), TEST_MODEL_PKG,
+                    null, Map.of("timestamp", before), before);
             Mockito.verify(accumulator).metadataValueUpdate(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER,
                     ProviderPackage.Literals.PROVIDER__ADMIN.getName(), ProviderPackage.Literals.ADMIN__MODEL.getName(),
-                    null, Map.of("timestamp", before), before);
+                    TEST_MODEL, null, Map.of("timestamp", before), before);
 
             Mockito.verify(accumulator).addService(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER, TEST_SERVICE);
             Mockito.verify(accumulator).addResource(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER, TEST_SERVICE,
@@ -300,9 +300,9 @@ public class SubscriptionTest {
                     now);
 
             Mockito.verify(accumulator).metadataValueUpdate(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER, TEST_SERVICE,
-                    TEST_RESOURCE, null, Map.of("timestamp", before), before);
+                    TEST_RESOURCE, TEST_VALUE, null, Map.of("timestamp", before), before);
             Mockito.verify(accumulator).metadataValueUpdate(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER, TEST_SERVICE,
-                    TEST_RESOURCE_2, null, Map.of("timestamp", now), now);
+                    TEST_RESOURCE_2, TEST_VALUE, null, Map.of("timestamp", now), now);
 
             Mockito.verifyNoMoreInteractions(accumulator);
         }
@@ -343,7 +343,7 @@ public class SubscriptionTest {
                     Map.of("timestamp", before), before);
             Mockito.verify(accumulator).metadataValueUpdate(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER,
                     ProviderPackage.Literals.PROVIDER__ADMIN.getName(),
-                    ProviderPackage.Literals.ADMIN__FRIENDLY_NAME.getName(), null,
+                    ProviderPackage.Literals.ADMIN__FRIENDLY_NAME.getName(), TEST_PROVIDER, null,
                     Map.of("timestamp", before), before);
             HashMap<String, Object> map = new HashMap<>();
             map.put("timestamp", before);
@@ -355,7 +355,7 @@ public class SubscriptionTest {
                     ProviderPackage.Literals.ADMIN__DESCRIPTION.getName(), String.class, null, null, map, before);
             Mockito.verify(accumulator).metadataValueUpdate(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER,
                     ProviderPackage.Literals.PROVIDER__ADMIN.getName(),
-                    ProviderPackage.Literals.ADMIN__DESCRIPTION.getName(), null, map, before);
+                    ProviderPackage.Literals.ADMIN__DESCRIPTION.getName(), null, null, map, before);
             Mockito.verify(accumulator).addResource(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER,
                     ProviderPackage.Literals.PROVIDER__ADMIN.getName(),
                     ProviderPackage.Literals.ADMIN__MODEL_PACKAGE_URI.getName());
@@ -372,11 +372,11 @@ public class SubscriptionTest {
                     before);
             Mockito.verify(accumulator).metadataValueUpdate(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER,
                     ProviderPackage.Literals.PROVIDER__ADMIN.getName(),
-                    ProviderPackage.Literals.ADMIN__MODEL_PACKAGE_URI.getName(), null,
-                    Map.of("timestamp", before), before);
+                    ProviderPackage.Literals.ADMIN__MODEL_PACKAGE_URI.getName(), TEST_MODEL_PKG,
+                    null, Map.of("timestamp", before), before);
             Mockito.verify(accumulator).metadataValueUpdate(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER,
                     ProviderPackage.Literals.PROVIDER__ADMIN.getName(), ProviderPackage.Literals.ADMIN__MODEL.getName(),
-                    null, Map.of("timestamp", before), before);
+                    TEST_MODEL, null, Map.of("timestamp", before), before);
 
             Mockito.verify(accumulator).addService(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER, TEST_SERVICE);
             Mockito.verify(accumulator).addService(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER, TEST_SERVICE_2);
@@ -392,9 +392,9 @@ public class SubscriptionTest {
                     now);
 
             Mockito.verify(accumulator).metadataValueUpdate(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER, TEST_SERVICE,
-                    TEST_RESOURCE, null, Map.of("timestamp", before), before);
+                    TEST_RESOURCE, TEST_VALUE, null, Map.of("timestamp", before), before);
             Mockito.verify(accumulator).metadataValueUpdate(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER, TEST_SERVICE_2,
-                    TEST_RESOURCE_2, null, Map.of("timestamp", now), now);
+                    TEST_RESOURCE_2, TEST_VALUE_2, null, Map.of("timestamp", now), now);
 
             Mockito.verifyNoMoreInteractions(accumulator);
         }
@@ -433,7 +433,7 @@ public class SubscriptionTest {
                     Map.of("timestamp", now), now);
             Mockito.verify(accumulator).metadataValueUpdate(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER,
                     ProviderPackage.Literals.PROVIDER__ADMIN.getName(),
-                    ProviderPackage.Literals.ADMIN__FRIENDLY_NAME.getName(), null,
+                    ProviderPackage.Literals.ADMIN__FRIENDLY_NAME.getName(), TEST_PROVIDER, null,
                     Map.of("timestamp", now), now);
             HashMap<String, Object> map = new HashMap<>();
             map.put("timestamp", now);
@@ -445,7 +445,7 @@ public class SubscriptionTest {
                     ProviderPackage.Literals.ADMIN__DESCRIPTION.getName(), String.class, null, null, map, now);
             Mockito.verify(accumulator).metadataValueUpdate(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER,
                     ProviderPackage.Literals.PROVIDER__ADMIN.getName(),
-                    ProviderPackage.Literals.ADMIN__DESCRIPTION.getName(), null, map, now);
+                    ProviderPackage.Literals.ADMIN__DESCRIPTION.getName(), null, null, map, now);
             Mockito.verify(accumulator).addResource(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER,
                     ProviderPackage.Literals.PROVIDER__ADMIN.getName(),
                     ProviderPackage.Literals.ADMIN__MODEL_PACKAGE_URI.getName());
@@ -462,11 +462,11 @@ public class SubscriptionTest {
                     now);
             Mockito.verify(accumulator).metadataValueUpdate(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER,
                     ProviderPackage.Literals.PROVIDER__ADMIN.getName(),
-                    ProviderPackage.Literals.ADMIN__MODEL_PACKAGE_URI.getName(), null,
-                    Map.of("timestamp", now), now);
+                    ProviderPackage.Literals.ADMIN__MODEL_PACKAGE_URI.getName(),
+                    model.getEPackage().getNsURI(), null, Map.of("timestamp", now), now);
             Mockito.verify(accumulator).metadataValueUpdate(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER,
                     ProviderPackage.Literals.PROVIDER__ADMIN.getName(), ProviderPackage.Literals.ADMIN__MODEL.getName(),
-                    null, Map.of("timestamp", now), now);
+                    TEST_MODEL, null, Map.of("timestamp", now), now);
 
             Mockito.verify(accumulator).addService(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER, TEST_SERVICE);
             Mockito.verify(accumulator).addService(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER, TEST_SERVICE);
@@ -476,7 +476,7 @@ public class SubscriptionTest {
                     TEST_RESOURCE, String.class, null, TEST_VALUE,
                     Map.of("timestamp", now, METADATA_KEY, METADATA_VALUE), now);
             Mockito.verify(accumulator).metadataValueUpdate(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER, TEST_SERVICE,
-                    TEST_RESOURCE, new HashMap<String, Object>() {
+                    TEST_RESOURCE, null, new HashMap<String, Object>() {
                         {
                             put("timestamp", null);
                         }
@@ -487,7 +487,7 @@ public class SubscriptionTest {
                         }
                     }, now);
             Mockito.verify(accumulator).metadataValueUpdate(TEST_MODEL_PKG, TEST_MODEL, TEST_PROVIDER, TEST_SERVICE,
-                    TEST_RESOURCE, new HashMap<String, Object>() {
+                    TEST_RESOURCE, TEST_VALUE, new HashMap<String, Object>() {
                         {
                             put(METADATA_KEY, METADATA_VALUE);
                             put("timestamp", null);
@@ -706,7 +706,7 @@ public class SubscriptionTest {
                     Map.of("timestamp", newMetadata.getTimestamp()),
                     newMetadata.getTimestamp());
             Mockito.verify(accumulator).metadataValueUpdate(ePackage.getNsURI(), modelName, provider.getId(),
-                    "testService1", "foo2", null,
+                    "testService1", "foo2", "somethingElse", null,
                     Map.of("timestamp", newMetadata.getTimestamp()),
                     newMetadata.getTimestamp());
             Mockito.verifyNoMoreInteractions(accumulator);
@@ -744,8 +744,6 @@ public class SubscriptionTest {
             ((Service) saved.eGet(provider.eClass().getEStructuralFeature("testService1")))
                     .eSet(testService1.eClass().getEStructuralFeature("foo"), "foo2");
 
-            Metadata oldMetadata = ((Service) saved.eGet(provider.eClass().getEStructuralFeature("testService1")))
-                    .getMetadata().get(testService1.eClass().getEStructuralFeature("foo"));
             ((Service) saved.eGet(provider.eClass().getEStructuralFeature("testService1"))).getMetadata().clear();
 
             Instant mark = Instant.now();
@@ -762,11 +760,10 @@ public class SubscriptionTest {
 
             String modelName = EMFUtil.getModelName(provider.eClass());
 
+            // We cleared the metadata in the update so this should be "resource only" and not trigger
+            // a metadata notification
             Mockito.verify(accumulator).resourceValueUpdate(ePackage.getNsURI(), modelName, provider.getId(),
                     "testService1", "foo", String.class, "foo", "foo2",
-                    Map.of("timestamp", curMetadata.getTimestamp()), curMetadata.getTimestamp());
-            Mockito.verify(accumulator).metadataValueUpdate(ePackage.getNsURI(), modelName, provider.getId(),
-                    "testService1", "foo", Map.of("timestamp", oldMetadata.getTimestamp()),
                     Map.of("timestamp", curMetadata.getTimestamp()), curMetadata.getTimestamp());
             Mockito.verifyNoMoreInteractions(accumulator);
         }
@@ -843,8 +840,8 @@ public class SubscriptionTest {
                             "timestamp", newMetadata.getTimestamp()),
                     newMetadata.getTimestamp());
             Mockito.verify(accumulator).metadataValueUpdate(ePackage.getNsURI(), modelName, provider.getId(),
-                    "testService1", "foo2", null, Map.of("test.meta.1", "some Test", "timestamp",
-                            newMetadata.getTimestamp()),
+                    "testService1", "foo2", "somethingElse", null, Map.of(
+                            "test.meta.1", "some Test", "timestamp", newMetadata.getTimestamp()),
                     newMetadata.getTimestamp());
             Mockito.verifyNoMoreInteractions(accumulator);
         }
@@ -923,7 +920,7 @@ public class SubscriptionTest {
                             "test.meta.2", 2, "timestamp", curMetadata.getTimestamp()),
                     curMetadata.getTimestamp());
             Mockito.verify(accumulator).metadataValueUpdate(
-                    ePackage.getNsURI(), modelName, provider.getId(), "testService1", "foo",
+                    ePackage.getNsURI(), modelName, provider.getId(), "testService1", "foo", "foo2",
                     Map.of("timestamp", oldMetadataTimestampToCompare), Map.of("test.meta.1",
                             "some Test", "test.meta.2", 2, "timestamp", curMetadata.getTimestamp()),
                     curMetadata.getTimestamp());
@@ -987,8 +984,8 @@ public class SubscriptionTest {
                             "testMetadata2", "timestamp", curMetadata.getTimestamp()),
                     curMetadata.getTimestamp());
             Mockito.verify(accumulator).metadataValueUpdate(ePackage.getNsURI(), modelName, provider.getId(),
-                    "testService2", "annotated", null, Map.of("test", "testMetadata", "test2", "testMetadata2",
-                            "timestamp", curMetadata.getTimestamp()),
+                    "testService2", "annotated", "avalue", null, Map.of("test", "testMetadata",
+                            "test2", "testMetadata2", "timestamp", curMetadata.getTimestamp()),
                     curMetadata.getTimestamp());
             Mockito.verifyNoMoreInteractions(accumulator);
         }
@@ -1069,8 +1066,8 @@ public class SubscriptionTest {
                             "testMetadata2", "timestamp", curMetadata.getTimestamp()),
                     curMetadata.getTimestamp());
             Mockito.verify(accumulator).metadataValueUpdate(ePackage.getNsURI(), modelName, provider.getId(),
-                    "testService2", "annotated", null, Map.of("test", mv.getValue(), "test2", "testMetadata2",
-                            "timestamp", curMetadata.getTimestamp()),
+                    "testService2", "annotated", "avalue", null, Map.of("test", mv.getValue(),
+                            "test2", "testMetadata2", "timestamp", curMetadata.getTimestamp()),
                     curMetadata.getTimestamp());
             Mockito.verifyNoMoreInteractions(accumulator);
         }
@@ -1151,7 +1148,7 @@ public class SubscriptionTest {
                     Map.of("test.meta.1", "some Test", "timestamp", curMetadata.getTimestamp()),
                     curMetadata.getTimestamp());
             Mockito.verify(accumulator).metadataValueUpdate(ePackage.getNsURI(), modelName, provider.getId(),
-                    "testService1", "foo",
+                    "testService1", "foo", "foo",
                     Map.of("test.meta.1", "some Test", "test.meta.2", 2, "timestamp",
                             oldMetadataTimestampToCompare),
                     Map.of("test.meta.1", "some Test", "timestamp", curMetadata.getTimestamp()),
@@ -1560,7 +1557,7 @@ public class SubscriptionTest {
                 provider.getId(), serviceName, attribute.getName(), attribute.getEType().getInstanceClass(), null,
                 value, Map.of("timestamp", time), time);
         Mockito.verify(accumulator).metadataValueUpdate(provider.eClass().getEPackage().getNsURI(), modelName,
-                provider.getId(), serviceName, attribute.getName(), null, Map.of("timestamp", time),
+                provider.getId(), serviceName, attribute.getName(), value, null, Map.of("timestamp", time),
                 time);
     }
 
@@ -1572,7 +1569,7 @@ public class SubscriptionTest {
                 attribute.getEType().getInstanceClass(), oldService.eGet(attribute), null, Mockito.any(),
                 Mockito.any());
         Mockito.verify(accumulator).metadataValueUpdate(provider.eClass().getEPackage().getNsURI(), modelName,
-                provider.getId(), oldService.eContainingFeature().getName(), attribute.getName(),
+                provider.getId(), oldService.eContainingFeature().getName(), attribute.getName(), null,
                 Map.of("timestamp", getTimestampForService(oldService, attribute)),
                 null, Mockito.any());
         Mockito.verify(accumulator).removeResource(provider.eClass().getEPackage().getNsURI(), modelName,
@@ -1590,9 +1587,9 @@ public class SubscriptionTest {
                 eq(attribute.getEType().getInstanceClass()), eq(oldService.eGet(attribute)),
                 eq(newService.eGet(attribute)), Mockito.any(), Mockito.any());
         Mockito.verify(accumulator).metadataValueUpdate(provider.eClass().getEPackage().getNsURI(), modelName,
-                provider.getId(), serviceName, attribute.getName(),
-                Map.of("value", oldService.eGet(attribute), "timestamp", getTimestampForService(oldService, attribute)),
-                Map.of("value", newService.eGet(attribute), "timestamp", getTimestampForService(newService, attribute)),
+                provider.getId(), serviceName, attribute.getName(), newService.eGet(attribute),
+                Map.of("timestamp", getTimestampForService(oldService, attribute)),
+                Map.of("timestamp", getTimestampForService(newService, attribute)),
                 getTimestampForService(newService, attribute));
     }
 

--- a/core/impl/src/test/java/org/eclipse/sensinact/core/notification/impl/NotificationSenderTest.java
+++ b/core/impl/src/test/java/org/eclipse/sensinact/core/notification/impl/NotificationSenderTest.java
@@ -379,11 +379,13 @@ class NotificationSenderTest {
         void testAddNullMetadata() {
             Instant now = Instant.now();
 
-            accumulator.metadataValueUpdate(MODEL_PKG, MODEL, PROVIDER, SERVICE, RESOURCE, null, null, now);
+            accumulator.metadataValueUpdate(MODEL_PKG, MODEL, PROVIDER, SERVICE, RESOURCE, INTEGER_VALUE,
+                    null, null, now);
             accumulator.completeAndSend();
 
             Mockito.verify(bus).deliver(eq("METADATA/" + MODEL + "/" + PROVIDER + "/" + SERVICE + "/" + RESOURCE),
-                    argThat(isMetadataNotificationWith(PROVIDER, SERVICE, RESOURCE, emptyMap(), emptyMap(), now)));
+                    argThat(isMetadataNotificationWith(PROVIDER, SERVICE, RESOURCE, INTEGER_VALUE,
+                            emptyMap(), emptyMap(), now)));
             Mockito.verifyNoMoreInteractions(bus);
         }
 
@@ -391,12 +393,12 @@ class NotificationSenderTest {
         void testAddNewMetadata() {
             Instant now = Instant.now();
 
-            accumulator.metadataValueUpdate(MODEL_PKG, MODEL, PROVIDER, SERVICE, RESOURCE, null,
-                    singletonMap(METADATA_KEY, METADATA_VALUE), now);
+            accumulator.metadataValueUpdate(MODEL_PKG, MODEL, PROVIDER, SERVICE, RESOURCE, INTEGER_VALUE,
+                    null, singletonMap(METADATA_KEY, METADATA_VALUE), now);
             accumulator.completeAndSend();
 
             Mockito.verify(bus).deliver(eq("METADATA/" + MODEL + "/" + PROVIDER + "/" + SERVICE + "/" + RESOURCE),
-                    argThat(isMetadataNotificationWith(PROVIDER, SERVICE, RESOURCE, emptyMap(),
+                    argThat(isMetadataNotificationWith(PROVIDER, SERVICE, RESOURCE, INTEGER_VALUE, emptyMap(),
                             singletonMap(METADATA_KEY, METADATA_VALUE), now)));
             Mockito.verifyNoMoreInteractions(bus);
         }
@@ -405,12 +407,12 @@ class NotificationSenderTest {
         void testRemoveMetadata() {
             Instant now = Instant.now();
 
-            accumulator.metadataValueUpdate(MODEL_PKG, MODEL, PROVIDER, SERVICE, RESOURCE,
+            accumulator.metadataValueUpdate(MODEL_PKG, MODEL, PROVIDER, SERVICE, RESOURCE, INTEGER_VALUE,
                     singletonMap(METADATA_KEY, METADATA_VALUE), null, now);
             accumulator.completeAndSend();
 
             Mockito.verify(bus).deliver(eq("METADATA/" + MODEL + "/" + PROVIDER + "/" + SERVICE + "/" + RESOURCE),
-                    argThat(isMetadataNotificationWith(PROVIDER, SERVICE, RESOURCE,
+                    argThat(isMetadataNotificationWith(PROVIDER, SERVICE, RESOURCE, INTEGER_VALUE,
                             singletonMap(METADATA_KEY, METADATA_VALUE), emptyMap(), now)));
             Mockito.verifyNoMoreInteractions(bus);
         }
@@ -419,15 +421,15 @@ class NotificationSenderTest {
         void testAddMetadataAcrossMultipleCalls() {
             Instant now = Instant.now();
 
-            accumulator.metadataValueUpdate(MODEL_PKG, MODEL, PROVIDER, SERVICE, RESOURCE, null,
-                    singletonMap(METADATA_KEY, METADATA_VALUE), now);
-            accumulator.metadataValueUpdate(MODEL_PKG, MODEL, PROVIDER, SERVICE, RESOURCE,
+            accumulator.metadataValueUpdate(MODEL_PKG, MODEL, PROVIDER, SERVICE, RESOURCE, INTEGER_VALUE,
+                    null, singletonMap(METADATA_KEY, METADATA_VALUE), now);
+            accumulator.metadataValueUpdate(MODEL_PKG, MODEL, PROVIDER, SERVICE, RESOURCE, INTEGER_VALUE_2,
                     singletonMap(METADATA_KEY, METADATA_VALUE),
                     Map.of(METADATA_KEY, METADATA_VALUE, METADATA_KEY_2, METADATA_VALUE_2), now);
             accumulator.completeAndSend();
 
             Mockito.verify(bus).deliver(eq("METADATA/" + MODEL + "/" + PROVIDER + "/" + SERVICE + "/" + RESOURCE),
-                    argThat(isMetadataNotificationWith(PROVIDER, SERVICE, RESOURCE, emptyMap(),
+                    argThat(isMetadataNotificationWith(PROVIDER, SERVICE, RESOURCE, INTEGER_VALUE_2, emptyMap(),
                             Map.of(METADATA_KEY, METADATA_VALUE, METADATA_KEY_2, METADATA_VALUE_2), now)));
             Mockito.verifyNoMoreInteractions(bus);
         }
@@ -436,15 +438,15 @@ class NotificationSenderTest {
         void testAddMetadataAcrossMultipleCallsWithTimeChange() {
             Instant now = Instant.now();
 
-            accumulator.metadataValueUpdate(MODEL_PKG, MODEL, PROVIDER, SERVICE, RESOURCE, null,
+            accumulator.metadataValueUpdate(MODEL_PKG, MODEL, PROVIDER, SERVICE, RESOURCE, INTEGER_VALUE, null,
                     singletonMap(METADATA_KEY, METADATA_VALUE), now.minusSeconds(10));
             accumulator.metadataValueUpdate(MODEL_PKG, MODEL, PROVIDER, SERVICE, RESOURCE,
-                    singletonMap(METADATA_KEY, METADATA_VALUE),
+                    INTEGER_VALUE_2, singletonMap(METADATA_KEY, METADATA_VALUE),
                     Map.of(METADATA_KEY, METADATA_VALUE, METADATA_KEY_2, METADATA_VALUE_2), now);
             accumulator.completeAndSend();
 
             Mockito.verify(bus).deliver(eq("METADATA/" + MODEL + "/" + PROVIDER + "/" + SERVICE + "/" + RESOURCE),
-                    argThat(isMetadataNotificationWith(PROVIDER, SERVICE, RESOURCE, emptyMap(),
+                    argThat(isMetadataNotificationWith(PROVIDER, SERVICE, RESOURCE, INTEGER_VALUE_2, emptyMap(),
                             Map.of(METADATA_KEY, METADATA_VALUE, METADATA_KEY_2, METADATA_VALUE_2), now)));
             Mockito.verifyNoMoreInteractions(bus);
         }
@@ -453,11 +455,11 @@ class NotificationSenderTest {
         void testAddMetadataAcrossMultipleCallsReverseTime() {
             Instant now = Instant.now();
 
-            accumulator.metadataValueUpdate(MODEL_PKG, MODEL, PROVIDER, SERVICE, RESOURCE, null,
+            accumulator.metadataValueUpdate(MODEL_PKG, MODEL, PROVIDER, SERVICE, RESOURCE, INTEGER_VALUE, null,
                     singletonMap(METADATA_KEY, METADATA_VALUE), now);
 
             Exception thrown = assertThrows(IllegalArgumentException.class, () -> {
-                accumulator.metadataValueUpdate(MODEL_PKG, MODEL, PROVIDER, SERVICE, RESOURCE,
+                accumulator.metadataValueUpdate(MODEL_PKG, MODEL, PROVIDER, SERVICE, RESOURCE, INTEGER_VALUE,
                         singletonMap(METADATA_KEY, METADATA_VALUE), Map.of(METADATA_KEY_2, METADATA_VALUE_2),
                         now.minusSeconds(10));
             });
@@ -469,15 +471,36 @@ class NotificationSenderTest {
         void testAddRemoveMetadataAcrossMultipleCalls() {
             Instant now = Instant.now();
 
-            accumulator.metadataValueUpdate(MODEL_PKG, MODEL, PROVIDER, SERVICE, RESOURCE, null,
+            accumulator.metadataValueUpdate(MODEL_PKG, MODEL, PROVIDER, SERVICE, RESOURCE, INTEGER_VALUE, null,
                     singletonMap(METADATA_KEY, METADATA_VALUE), now.minusSeconds(10));
-            accumulator.metadataValueUpdate(MODEL_PKG, MODEL, PROVIDER, SERVICE, RESOURCE,
+            accumulator.metadataValueUpdate(MODEL_PKG, MODEL, PROVIDER, SERVICE, RESOURCE, INTEGER_VALUE_2,
                     singletonMap(METADATA_KEY, METADATA_VALUE), singletonMap(METADATA_KEY_2, METADATA_VALUE_2), now);
             accumulator.completeAndSend();
 
             Mockito.verify(bus).deliver(eq("METADATA/" + MODEL + "/" + PROVIDER + "/" + SERVICE + "/" + RESOURCE),
-                    argThat(isMetadataNotificationWith(PROVIDER, SERVICE, RESOURCE, emptyMap(),
+                    argThat(isMetadataNotificationWith(PROVIDER, SERVICE, RESOURCE, INTEGER_VALUE_2, emptyMap(),
                             Map.of(METADATA_KEY_2, METADATA_VALUE_2), now)));
+            Mockito.verifyNoMoreInteractions(bus);
+        }
+
+        @Test
+        void testMetadataUpdateFixesUpResourceUpdate() {
+            Instant now = Instant.now();
+
+            // Create a resource and metadata, update the resource
+            accumulator.resourceValueUpdate(MODEL_PKG, MODEL, PROVIDER, SERVICE, RESOURCE, Integer.class, null, INTEGER_VALUE,
+                    Map.of(METADATA_KEY, METADATA_VALUE), now);
+            accumulator.metadataValueUpdate(MODEL_PKG, MODEL, PROVIDER, SERVICE, RESOURCE, INTEGER_VALUE,
+                    null, Map.of(METADATA_KEY, METADATA_VALUE_2), now);
+            accumulator.completeAndSend();
+
+            // The data event should be using the second metadata value
+            Mockito.verify(bus).deliver(eq("DATA/" + MODEL + "/" + PROVIDER + "/" + SERVICE + "/" + RESOURCE), argThat(
+                    isValueNotificationWith(PROVIDER, SERVICE, RESOURCE, Integer.class, null, INTEGER_VALUE,
+                            Map.of(METADATA_KEY, METADATA_VALUE_2), now)));
+            Mockito.verify(bus).deliver(eq("METADATA/" + MODEL + "/" + PROVIDER + "/" + SERVICE + "/" + RESOURCE), argThat(
+                    isMetadataNotificationWith(PROVIDER, SERVICE, RESOURCE, INTEGER_VALUE, Map.of(),
+                            Map.of(METADATA_KEY, METADATA_VALUE_2), now)));
             Mockito.verifyNoMoreInteractions(bus);
         }
     }
@@ -520,7 +543,7 @@ class NotificationSenderTest {
 
             accumulator.resourceValueUpdate(MODEL_PKG, MODEL, PROVIDER, SERVICE, RESOURCE, Integer.class, null, INTEGER_VALUE,
                     Map.of(METADATA_KEY, METADATA_VALUE), now);
-            accumulator.metadataValueUpdate(MODEL_PKG, MODEL, PROVIDER, SERVICE, RESOURCE,
+            accumulator.metadataValueUpdate(MODEL_PKG, MODEL, PROVIDER, SERVICE, RESOURCE, INTEGER_VALUE,
                     Map.of(METADATA_KEY, METADATA_VALUE), Map.of(METADATA_KEY, METADATA_VALUE_2), now);
             accumulator.completeAndSend();
 
@@ -528,8 +551,8 @@ class NotificationSenderTest {
                     isValueNotificationWith(PROVIDER, SERVICE, RESOURCE, Integer.class, null, INTEGER_VALUE,
                             Map.of(METADATA_KEY, METADATA_VALUE_2), now)));
             Mockito.verify(bus).deliver(eq("METADATA/" + MODEL + "/" + PROVIDER + "/" + SERVICE + "/" + RESOURCE),
-                    argThat(isMetadataNotificationWith(PROVIDER, SERVICE, RESOURCE, Map.of(METADATA_KEY, METADATA_VALUE),
-                            Map.of(METADATA_KEY, METADATA_VALUE_2), now)));
+                    argThat(isMetadataNotificationWith(PROVIDER, SERVICE, RESOURCE, INTEGER_VALUE,
+                            Map.of(METADATA_KEY, METADATA_VALUE), Map.of(METADATA_KEY, METADATA_VALUE_2), now)));
             Mockito.verifyNoMoreInteractions(bus);
         }
 
@@ -577,6 +600,29 @@ class NotificationSenderTest {
             });
 
             assertTrue(thrown.getMessage().contains("out of temporal order"), "Wrong message: " + thrown.getMessage());
+        }
+
+        @Test
+        void testResourceUpdateAfterMetadataUpdate() {
+            Instant now = Instant.now();
+
+            // Create a resource and metadata, update the resource
+            accumulator.resourceValueUpdate(MODEL_PKG, MODEL, PROVIDER, SERVICE, RESOURCE, Integer.class, null, INTEGER_VALUE,
+                    Map.of(METADATA_KEY, METADATA_VALUE), now);
+            accumulator.metadataValueUpdate(MODEL_PKG, MODEL, PROVIDER, SERVICE, RESOURCE, INTEGER_VALUE,
+                    null, Map.of(METADATA_KEY, METADATA_VALUE), now);
+            accumulator.resourceValueUpdate(MODEL_PKG, MODEL, PROVIDER, SERVICE, RESOURCE, Integer.class, INTEGER_VALUE,
+                    INTEGER_VALUE_2, Map.of(METADATA_KEY, METADATA_VALUE_2), now);
+            accumulator.completeAndSend();
+
+            // The metadata event should be using the second data value
+            Mockito.verify(bus).deliver(eq("DATA/" + MODEL + "/" + PROVIDER + "/" + SERVICE + "/" + RESOURCE), argThat(
+                    isValueNotificationWith(PROVIDER, SERVICE, RESOURCE, Integer.class, null, INTEGER_VALUE_2,
+                            Map.of(METADATA_KEY, METADATA_VALUE_2), now)));
+            Mockito.verify(bus).deliver(eq("METADATA/" + MODEL + "/" + PROVIDER + "/" + SERVICE + "/" + RESOURCE), argThat(
+                    isMetadataNotificationWith(PROVIDER, SERVICE, RESOURCE, INTEGER_VALUE_2, Map.of(),
+                            Map.of(METADATA_KEY, METADATA_VALUE_2), now)));
+            Mockito.verifyNoMoreInteractions(bus);
         }
     }
 
@@ -743,9 +789,9 @@ class NotificationSenderTest {
                     Map.of(METADATA_KEY_2, METADATA_VALUE_2), now);
             accumulator.resourceValueUpdate(MODEL_PKG, MODEL, PROVIDER, SERVICE, RESOURCE, Integer.class, null, INTEGER_VALUE_2,
                     Map.of(METADATA_KEY, METADATA_VALUE), now);
-            accumulator.metadataValueUpdate(MODEL_PKG, MODEL, PROVIDER, SERVICE, RESOURCE_2, null,
+            accumulator.metadataValueUpdate(MODEL_PKG, MODEL, PROVIDER, SERVICE, RESOURCE_2, INTEGER_VALUE, null,
                     singletonMap(METADATA_KEY_2, METADATA_VALUE_2), now);
-            accumulator.metadataValueUpdate(MODEL_PKG, MODEL, PROVIDER, SERVICE, RESOURCE, null,
+            accumulator.metadataValueUpdate(MODEL_PKG, MODEL, PROVIDER, SERVICE, RESOURCE, INTEGER_VALUE_2, null,
                     singletonMap(METADATA_KEY, METADATA_VALUE), now);
             accumulator.addResource(MODEL_PKG, MODEL, PROVIDER_2, SERVICE_2, RESOURCE_2);
             accumulator.addResource(MODEL_PKG, MODEL, PROVIDER_2, SERVICE_2, RESOURCE);
@@ -799,10 +845,10 @@ class NotificationSenderTest {
 
             // Metadata next
             inOrder.verify(bus).deliver(eq("METADATA/" + MODEL + "/" + PROVIDER + "/" + SERVICE + "/" + RESOURCE),
-                    argThat(isMetadataNotificationWith(PROVIDER, SERVICE, RESOURCE, emptyMap(),
+                    argThat(isMetadataNotificationWith(PROVIDER, SERVICE, RESOURCE, INTEGER_VALUE_2, emptyMap(),
                             singletonMap(METADATA_KEY, METADATA_VALUE), now)));
             inOrder.verify(bus).deliver(eq("METADATA/" + MODEL + "/" + PROVIDER + "/" + SERVICE + "/" + RESOURCE_2),
-                    argThat(isMetadataNotificationWith(PROVIDER, SERVICE, RESOURCE_2, emptyMap(),
+                    argThat(isMetadataNotificationWith(PROVIDER, SERVICE, RESOURCE_2, INTEGER_VALUE, emptyMap(),
                             singletonMap(METADATA_KEY_2, METADATA_VALUE_2), now)));
 
             // Resource values next
@@ -855,13 +901,14 @@ class NotificationSenderTest {
     }
 
     ArgumentMatcher<ResourceMetaDataNotification> isMetadataNotificationWith(String provider, String service,
-            String resource, Map<String, Object> oldValues, Map<String, Object> newValues, Instant timestamp) {
+            String resource, Object value, Map<String, Object> oldValues, Map<String, Object> newValues, Instant timestamp) {
         return i -> {
             try {
                 assertEquals(MODEL, i.model());
                 assertEquals(provider, i.provider());
                 assertEquals(service, i.service());
                 assertEquals(resource, i.resource());
+                assertEquals(value, i.data());
                 assertEquals(oldValues, i.oldValues());
                 assertEquals(newValues, i.newValues());
                 assertEquals(timestamp, i.timestamp());


### PR DESCRIPTION
This commit fixes the behaviour of metadata notifications to make them more efficient and more useful. Metadata events now contain the data value that was in force when the metadata update was applied, and are only sent when metadata is changed, not when the value is changed. Therefore:

 * A metadata event is sent when the resource is first created with its initial metadata
 * A metadata event is *not* sent when the resource value changes, even though the timestamp updates
 * A metadata event *is* sent when the metadata changes
 * A metadata event will contain the *latest* value, so if a value update occurs after a metatdata update for the same resource the event will contain the updated data value.
 * A data event will contain the *latest* metadata, so if a metadata update occurs after a value update for the same resource the event will contain the updated metadata values.

As before, once an update command completes the events are generated and sent.