### PR TITLE
Remove generated EMF sources on clean

### DIFF
--- a/core/models/provider/pom.xml
+++ b/core/models/provider/pom.xml
@@ -70,6 +70,17 @@
         <artifactId>bnd-maven-plugin</artifactId>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-clean-plugin</artifactId>
+        <configuration>
+          <filesets>
+            <fileset>
+              <directory>src/main/java</directory>
+            </fileset>
+          </filesets>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>biz.aQute.bnd</groupId>
         <artifactId>bnd-generate-maven-plugin</artifactId>
         <version>${bnd.version}</version>

--- a/core/models/testdata/pom.xml
+++ b/core/models/testdata/pom.xml
@@ -51,6 +51,17 @@
         <artifactId>bnd-maven-plugin</artifactId>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-clean-plugin</artifactId>
+        <configuration>
+          <filesets>
+            <fileset>
+              <directory>src/main/java</directory>
+            </fileset>
+          </filesets>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>biz.aQute.bnd</groupId>
         <artifactId>bnd-generate-maven-plugin</artifactId>
         <version>${bnd.version}</version>


### PR DESCRIPTION
bnd-generate writes codegen output into src/main/java with clear=false and no clean fileset covered it, so stale generated sources survived 'mvn clean' and broke the build after the Gecko to Fennec package rename.